### PR TITLE
merge of updated docker-compose based on fuel-cells example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ base docker images are available on docker hub at https://hub.docker.com/r/voltt
 
 # Usage
 
-```` bash
+``` bash
 # Retrieves and executes the volttron container.
 docker run -it volttron/volttron
-````
+```
 
 After entering the above command the shell will be within the volttron container as a user named volttron.
 
-```` bash
+``` bash
 # starting the platform
 volttron -vv -l volttron.log&
 
@@ -25,13 +25,14 @@ python scripts/core/make-listener
 
 # see the log messages
 tail -f volttron.log
-````
+```
 
 All the same functionality that one would have from a VOLTTRON command line is available through the container.
 
 # Platform Initialization
 
 The VOLTTRON container when created is just a blank container with no agents.  Now there is an initialization routine available within the docker container to allow the installation of agents before launching of the instance.  To do this one will mount a platform_config.yml file to /platform_config.yml.  The recommended way to do this is through a docker-compose.yml file.  An example of this is available https://github.com/VOLTTRON/volttron-fuel-cells/.
+Note that agents within the `platform_config.yml` file are created sequentailly, it can take several seconds for each to spin up and be visible via `vctl` commands.
 
 # Advanced Usage
 
@@ -39,9 +40,8 @@ In order for volttron to keep its state between runs, the state must be stored o
 
 1. Create a directory (mkdir -p vhome).  This is where the VOLTTRON_HOME inside the container will be created on the host.
 1. Start the docker container with a volume mount point and pass a LOCAL_USER_ID environtmental variable.
-    ```` bash
+    ``` bash
     docker run -e LOCAL_USER_ID=$UID -v /home/user/vhome:/home/volttron/.volttron -it volttron/volttron
-    ````
+    ```
 
 In order to allow an external instance connect to the running volttron container one must add the -p <hostport>:<containerport> (e.g. 22916:22916)
-

--- a/README.md
+++ b/README.md
@@ -1,33 +1,8 @@
 # Official VOLTTRON docker image
 
 # Introduction
-This image provides a reproducable way to install VOLTTRON within a docker container.  It features gosu which allows the storage of VOLTTRON_HOME to be persistable on the hosts hard drive.  The
-base docker images are available on docker hub at https://hub.docker.com/r/volttron/volttron/.
-
-# Raw Container Usage
-
-``` bash
-# Retrieves and executes the volttron container.
-docker run -it volttron/volttron
-```
-
-After entering the above command the shell will be within the volttron container as a user named volttron.
-
-``` bash
-# starting the platform
-volttron -vv -l volttron.log&
-
-# cd to volttron root
-cd $VOLTTRON_ROOT
-
-# installing listener agent
-python scripts/core/make-listener
-
-# see the log messages
-tail -f volttron.log
-```
-
-All the same functionality that one would have from a VOLTTRON command line is available through the container.
+This image provides a reproducable way to install VOLTTRON within a docker container.  It features gosu which allows the storage of VOLTTRON_HOME to be persistable on the hosts hard drive.
+The base docker images are available on docker hub at https://hub.docker.com/r/volttron/volttron/.
 
 # Platform Initialization
 
@@ -101,6 +76,31 @@ agents:
 
 ## Other Notes
 agents within the `platform_config.yml` file are created sequentailly, it can take several seconds for each to spin up and be visible via `vctl` commands.
+
+# Raw Container Usage
+
+``` bash
+# Retrieves and executes the volttron container.
+docker run -it volttron/volttron
+```
+
+After entering the above command the shell will be within the volttron container as a user named volttron.
+
+``` bash
+# starting the platform
+volttron -vv -l volttron.log&
+
+# cd to volttron root
+cd $VOLTTRON_ROOT
+
+# installing listener agent
+python scripts/core/make-listener
+
+# see the log messages
+tail -f volttron.log
+```
+
+All the same functionality that one would have from a VOLTTRON command line is available through the container.
 
 # Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Official VOLTTRON docker image
 
 # Introduction
-This image provides a reproducable way to install VOLTTRON within a docker container.  It features gosu which allows the storage of VOLTTRON_HOME to be persistable on the hosts hard drive.  The
-base docker images are available on docker hub at https://hub.docker.com/r/volttron/volttron/.
+This image provides a reproducable way to install VOLTTRON within a docker container.
+By using a volume mount of the `VOLTTRON_HOME` directory, runtime changes made by the platform are visible on the host and are preserved across instances of the container.
+Similarly, changes made from the host are reflect in the container.
+The image features gosu, which allows the non-root user executing the volttron platform inside the container to have the same UID as the host user running the container on the host system.
+In conjection with volume mounting of the directory, this ensures that file ownership and permissions in `VOLTTRON_HOME` match the host user, avoiding cases were root in the container leaves files inaccessible to a user without sudo permissions on the host.
 
 # Raw Container Usage
 
@@ -54,11 +57,11 @@ config:
 
 ## Agent Configuration
 The agent configuration section is under a top-level key "agents" and contains several layers of nested key-value mappings.
-The top level of the section is keyed with the names of the desired agents, each of which contains a mapping.
-For each agent, the mapping must contain a `source` key and may contain either or both a `config` and/or `config_store` key; the values are strings representing resolvable paths.
+The top level of the section is keyed with the names of the desired agents, which are used as the identity of those agents within the platform.
+For each agent key, there is a further mapping which must contain a `source` key and may contain either or both a `config` and/or `config_store` key; the values are strings representing resolvable paths.
 An example follows at the end of this section.
 
-Note that the agent section does not contain the detailed configuration of the agents, but only a path to the `identity.config` file for the agent which contains the actual details.
+Note that the agent section does not contain the detailed configuration of the agents; for each agent it gives a path to a dedicated configuration file for that agent.
 As with the `platform_config.yaml` file, it is generally desirable to mount a local directory containing the configurations into the container, again using a `docker-compose.yaml` file.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ All the same functionality that one would have from a VOLTTRON command line is a
 
 # Platform Initialization
 
-The VOLTTRON container when created is just a blank container with no agents.  Now there is an initialization routine available within the docker container to allow the installation of agents before launching of the instance.  To do this one will mount a platform_config.yml file to /platform_config.yml.  The recommended way to do this is through a docker-compose.yml file.  An example of this is available https://github.com/VOLTTRON/volttron-fuel-cells/.
-Note that agents within the `platform_config.yml` file are created sequentailly, it can take several seconds for each to spin up and be visible via `vctl` commands.
+The VOLTTRON container when created is just a blank container with no agents.  Now there is an initialization routine available within the docker container to allow the installation of agents before launching of the instance.  To do this one will mount a `platform_config.yml` file to `/platform_config.yml` within the container. One is also likely to need to mount agent configurations (specified in the `platform_config.yml` file), into the container. The recommended way to do this is through a `docker-compose.yml` file.  An example of this is included in this repository, based on the one in the [volttron-fuel-cells repo](https://github.com/VOLTTRON/volttron-fuel-cells/).
+
+The `platform_config.yml` file has two sections: `config`, which configures the main instance and populate's the main config file ($VOLTTRON_HOME/config), and `agents`, which contains a list of agents with references to configurations for them (note the frequent use of environment variables in this section).
+
+## Other Notes
+agents within the `platform_config.yml` file are created sequentailly, it can take several seconds for each to spin up and be visible via `vctl` commands.
 
 # Advanced Usage
 

--- a/configs/historian.config
+++ b/configs/historian.config
@@ -1,0 +1,8 @@
+{
+    "connection": {
+      "type": "sqlite",
+      "params": {
+        "database": "data/historian.sqlite"
+      }
+    }
+}

--- a/configs/listener.config
+++ b/configs/listener.config
@@ -1,0 +1,8 @@
+{
+   "message": "hello",
+    # log-level can be DEBUG, INFO, WARN or ERROR
+    # verbosity is decreased from left to right above
+    # default: INFO
+    "log-level": "INFO",
+    "heartbeat_period": 60
+}

--- a/core/bootstart.sh
+++ b/core/bootstart.sh
@@ -1,7 +1,6 @@
 #! /usr/bin/env bash
 
-# Uncomment if we are going to pre-setup the platform before
-# running any of the environment.
+# We are going to pre-setup the platform before running any of the environment.
 if [[ -z /startup/setup-platform.py ]]; then
     echo "/startup/setup-platform.py does not exist.  The docker image must be corrupted"
     exit 1
@@ -9,6 +8,7 @@ fi
 
 echo "Right before setup-platform.py is called I am calling printenv"
 printenv
+
 python /startup/setup-platform.py
 setup_return=$?
 if [[ $setup_return ]]; then
@@ -16,10 +16,7 @@ if [[ $setup_return ]]; then
     exit $setup_return
 fi
 
-# TODO
-# does setup-playtform.py return its PID? or do you not mean PID?
-# should `volttron -vv` be run if setup-platform fails?
-
+# Now spin up the volttron platform
 volttron -vv
 volttron_retcode=$?
 if [[ $volttron_retcode ]]; then

--- a/core/bootstart.sh
+++ b/core/bootstart.sh
@@ -10,10 +10,23 @@ fi
 echo "Right before setup-platform.py is called I am calling printenv"
 printenv
 python /startup/setup-platform.py
-PID=$?
-echo "PID WAS $PID"
-if [[ "$PID" == "0" ]]; then
-    volttron -vv
+setup_return=$?
+if [[ $setup_return ]]; then
+    echo "error running setup-platform.py"
+    exit $setup_return
 fi
 
+# TODO
+# does setup-playtform.py return its PID? or do you not mean PID?
+# should `volttron -vv` be run if setup-platform fails?
 
+#PID=$?
+#echo "PID WAS $PID"
+#if [[ "$setup_return" == "0" ]]; then
+    volttron -vv
+    volttron_retcode=$?
+#fi
+if [[ $volttron_retcode ]]; then
+  echo "volttron error"
+  exit $volttron_retcode
+fi

--- a/core/bootstart.sh
+++ b/core/bootstart.sh
@@ -20,12 +20,8 @@ fi
 # does setup-playtform.py return its PID? or do you not mean PID?
 # should `volttron -vv` be run if setup-platform fails?
 
-#PID=$?
-#echo "PID WAS $PID"
-#if [[ "$setup_return" == "0" ]]; then
-    volttron -vv
-    volttron_retcode=$?
-#fi
+volttron -vv
+volttron_retcode=$?
 if [[ $volttron_retcode ]]; then
   echo "volttron error"
   exit $volttron_retcode

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 version: '3'
-#volumes:
-#  env:
 services:
   volttron:
     hostname: vc
@@ -14,16 +12,7 @@ services:
       #- 25671:15671  # management port
     volumes:
       - ./platform_config.yml:/platform_config.yml
-      #- ./platform_config.yml.works:/platform_config.yml
       - ./configs:/home/volttron/configs
-     # - env:/code/volttron/env
-     # - /home/osboxes/repos/volttron-rabbitmq:/code/volttron
-     # - /home/osboxes/repos/docker-vhomes/vhome-rabbit:/home/volttron/.volttron
-      # - /home/osboxes/repos/volttron-rabbitmq/volttron:/code/volttron/volttron
-      # - /home/osboxes/repos/volttron-rabbitmq/services:/code/volttron/services
-      # - /home/osboxes/repos/volttron-rabbitmq/scripts:/code/volttron/scripts
-      # - /home/osboxes/repos/volttron-rabbitmq/volttron_data:/code/volttron/volttron_data
-      # - /home/osboxes/repos/volttron-rabbitmq/examples:/code/volttron/examples
     environment:
       - CONFIG=/home/volttron/configs
       - IGNORE_ENV_CHECK=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3'
 services:
   volttron:
     hostname: vc
-    #image: volttron-rabbitmq
     image: volttron/volttron
     ports:
        - 23916:22916

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,20 @@
 version: '3'
-volumes:
-  env:
+#volumes:
+#  env:
 services:
   volttron:
     hostname: vc
-    image: volttron-rabbitmq
+    #image: volttron-rabbitmq
+    image: volttron/volttron
     ports:
-      # - 23916:22916
-      - 8443:8443
-      - 6671:5671    # ampqs port
-      - 25671:15671  # management port
+       - 23916:22916
+       - 8080:8080
+      #- 8443:8443
+      #- 6671:5671    # ampqs port
+      #- 25671:15671  # management port
     volumes:
       - ./platform_config.yml:/platform_config.yml
+      #- ./platform_config.yml.works:/platform_config.yml
       - ./configs:/home/volttron/configs
      # - env:/code/volttron/env
      # - /home/osboxes/repos/volttron-rabbitmq:/code/volttron
@@ -23,6 +26,7 @@ services:
       # - /home/osboxes/repos/volttron-rabbitmq/examples:/code/volttron/examples
     environment:
       - CONFIG=/home/volttron/configs
+      - IGNORE_ENV_CHECK=1
       - LOCAL_USER_ID=1000
 
 #- LOCAL_USER_ID=1000

--- a/platform_config.yml
+++ b/platform_config.yml
@@ -6,14 +6,14 @@ config:
   vip-address: tcp://0.0.0.0:22916
   # For rabbitmq this should match the hostname specified in
   # in the docker compose file hostname field for the service.
-  bind-web-address: https://vc:8443
-  volttron-central-address: https://vc:8443
+  bind-web-address: http://0.0.0.0:8080
+  #volttron-central-address: https://vc:8443
   instance-name: foobar
-  message-bus: rmq
+  message-bus: zmq
   # volttron-central-address: a different address
   # volttron-central-serverkey: a different key
 
-rabbitmq-config: $CONFIG/rabbitmq_config.yml
+#rabbitmq-config: $CONFIG/rabbitmq_config.yml
 
 # Agents dictionary to install.  The key must be a valid
 # identity for the agent to be installed correctly.
@@ -21,32 +21,36 @@ agents:
 
   # Each agent identity.config file should be in the configs
   # directory and will be used to install the agent.
-  #listener:
-  #  source: $VOLTTRON_ROOT/examples/ListenerAgent
-  #  config: ~ # This is an empty element $CONFIG/listener.config
+  listener:
+    source: $VOLTTRON_ROOT/examples/ListenerAgent
+    config: $CONFIG/listener.config # This is an empty element $CONFIG/listener.config
 
   volttron.central:
     source: $VOLTTRON_ROOT/services/core/VolttronCentral
     config: $VOLTTRON_ROOT/services/core/VolttronCentral/config
 
+  master.driver:
+    source: $VOLTTRON_ROOT/services/core/MasterDriverAgent
+
   platform.agent:
     source: $VOLTTRON_ROOT/services/core/VolttronCentralPlatform
     config: $VOLTTRON_ROOT/services/core/VolttronCentralPlatform/config
+
+  historian:
+    source: $VOLTTRON_ROOT/services/core/SQLHistorian
+    config: $CONFIG/historian.config
+
 #  platform.actuator:
 #    source: $VOLTTRON_ROOT/services/core/ActuatorAgent
-#
-#  historian:
-#    source: $VOLTTRON_ROOT/services/core/SQLHistorian
-#    config: $CONFIG/historian.config
 #
 #  weather:
 #    source: $VOLTTRON_ROOT/examples/DataPublisher
 #    config: $CONFIG/weather.config
-#
+
 #  price:
 #    source: $VOLTTRON_ROOT/examples/DataPublisher
 #    config: $CONFIG/price.config
-#
+
 #  platform.bacnet_proxy:
 #    source: $VOLTTRON_ROOT/services/core/BACnetProxy
 #    config: $CONFIG/bacnet-proxy.json


### PR DESCRIPTION
Some questions before this is actually ready:

* There were more agents in the fuel-cells example, I can bring the rest of those over (or others), but I'm not sure what I expect them to do other than run when I spin everything up; are there particular tests?
* This repo seems to now be doing several distinct things (below), is that desired? Is there a clear scope for what this repo or for now is it just a catch-all?
  * home for script to install docker on ubuntu
  * home for a container image build (based on clone of another repo as a build step)
  * home for this example platform_config.yml and and docker_compose.yml; which run against hosted container image, not a local build
* Do you have particular expectations for commits? (signing, rebase to squash things, whatever)