### PR TITLE
multi-architecture build automation on travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,13 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# scripting output/products
+.travis/Dockerfile
+.travis/this_qemu
+
+#editor files
+*.swp
+
 # C extensions
 *.so
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "volttron"]
 	path = volttron
 	url = https://github.com/volttron/volttron
-	branch = rabbitmq-volttron
+	branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "volttron"]
+	path = volttron
+	url = https://github.com/volttron/volttron
+	branch = rabbitmq-volttron

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,33 +21,36 @@ addons:
     packages:
       - qemu-user-static
 
-# prepare the machine before any code
-# installation scripts
-before_install:
-  - './.travis/main.sh'
-  - './.travis/setup_emulation.sh'
+jobs:
+  include:
+    # prepare the machine before any code
+    # installation scripts
+    before_install:
+      - './.travis/main.sh'
+      - './.travis/setup_emulation.sh'
 
-#install:
-#  - python2 bootstrap.py
-  # Installs testing toolkit
-  #- python2 bootstrap.py --crate
-#  - python2 bootstrap.py --testing
+    #install:
+    #  - python2 bootstrap.py
+      # Installs testing toolkit
+      #- python2 bootstrap.py --crate
+    #  - python2 bootstrap.py --testing
 
-script:
-  #- 'ci-integration/run-tests.sh'
-  - './.travis/build-docker.sh -b'
+    script:
+      #- 'ci-integration/run-tests.sh'
+      - './.travis/build-docker.sh -b'
+      - .travis/bootstrap_image.sh -u amd64 -r debian -t 9 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _`
 
-# only execute the following instructions in
-# the case of a success (failing at this point
-# won't mark the build as a failure).
-# To have `DOCKER_USERNAME` and `DOCKER_PASSWORD`
-# filled you need to either use `travis`' cli 
-# and then `travis set ..` or go to the travis
-# page of your repository and then change the 
-# environment in the settings pannel.
-after_success:
-  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
-      docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
-      ./.travis/build-docker.sh -p ;
-    fi
+    # only execute the following instructions in
+    # the case of a success (failing at this point
+    # won't mark the build as a failure).
+    # To have `DOCKER_USERNAME` and `DOCKER_PASSWORD`
+    # filled you need to either use `travis`' cli 
+    # and then `travis set ..` or go to the travis
+    # page of your repository and then change the 
+    # environment in the settings pannel.
+    after_success:
+      - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
+          ./.travis/build-docker.sh -p ;
+        fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,24 +33,24 @@ addons:
 jobs:
   include:
     ## a stage to take build a new base image with python dependencies included (this is slow on some architectures)
-    - stage: preinstall
-      name: prebuild amd64
-      before_install:
-        - './.travis/main.sh'
-        - './.travis/setup_emulation.sh'
-      script:
-        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
-    - stage: preinstall
-      name: prebuild arm7
-      before_install:
-        - './.travis/main.sh'
-        - './.travis/setup_emulation.sh'
-      script:
-        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
-        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    #- stage: preinstall
+    #  name: prebuild amd64
+    #  before_install:
+    #    - './.travis/main.sh'
+    #    - './.travis/setup_emulation.sh'
+    #  script:
+    #    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    #    - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+    #    - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    #- stage: preinstall
+    #  name: prebuild arm7
+    #  before_install:
+    #    - './.travis/main.sh'
+    #    - './.travis/setup_emulation.sh'
+    #  script:
+    #    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    #    - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+    #    - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
     ## actually install our software on top of the above
     - stage: install
       name: build amd64
@@ -94,7 +94,7 @@ jobs:
         - './.travis/main.sh'
         - './.travis/setup_emulation.sh'
       script:
-        - .travis/bootstrap_image.sh -u laroque -r volttron-docker -t deps-`echo ${TRAVIS_BRANCH} | tr / _` -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u laroque -r volttron-docker -t deps-`echo ${TRAVIS_BRANCH} | tr / _`-arm -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
       after_success:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,3 +57,17 @@ jobs:
         #  fi
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - .travis/bootstrap_image.sh -u amd64 -r debian -t 10 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    - stage: install
+      name: build arm7
+      before_install:
+        - './.travis/main.sh'
+        - './.travis/setup_emulation.sh'
+      script:
+        - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+      after_success:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    - stage: manifest
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - .travis/build_manifest.sh -a arm -a amd64 -n laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _`

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
 
       script:
         #- .travis/bootstrap_image.sh -u amd64 -r debian -t 10 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
 
       # only execute the following instructions in
       # the case of a success (failing at this point
@@ -64,17 +64,17 @@ jobs:
         #    ./.travis/build-docker.sh -p ;
         #  fi
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
     - stage: install
       name: build arm7
       before_install:
         - './.travis/main.sh'
         - './.travis/setup_emulation.sh'
       script:
-        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
       after_success:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
     - stage: manifest
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ addons:
 
 jobs:
   include:
+    ## a stage to take build a new base image with python dependencies included (this is slow on some architectures)
     - stage: preinstall
       name: prebuild amd64
       before_install:
@@ -50,6 +51,7 @@ jobs:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
         - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    ## actually install our software on top of the above
     - stage: install
       name: build amd64
       # prepare the machine before any code
@@ -92,7 +94,7 @@ jobs:
         - './.travis/main.sh'
         - './.travis/setup_emulation.sh'
       script:
-        - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u laroque -r volttron-docker -t deps-`echo ${TRAVIS_BRANCH} | tr / _` -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
       after_success:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ jobs:
         - './.travis/main.sh'
         - './.travis/setup_emulation.sh'
       script:
-        - .travis/bootstrap_image.sh -u arm32v7 -r 2.7 -t 2.7 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
       after_success:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,10 @@ jobs:
       #  - python2 bootstrap.py --testing
 
       script:
-        #- .travis/bootstrap_image.sh -u amd64 -r debian -t 10 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        # build/push an intermediate container
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -f Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -f Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        # build the image itself
         - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
 
       # only execute the following instructions in

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ addons:
       - libevent-dev
       - git
 
+env:
+  - DOCKER_CLI_EXPERIMENTAL=enabled
+
 jobs:
   include:
     ## a stage to take build a new base image with python dependencies included (this is slow on some architectures)

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,9 @@ jobs:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
     - stage: manifest
+      before_install:
+        - './.travis/main.sh'
+        #- './.travis/setup_emulation.sh'
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - .travis/build_manifest.sh -a arm -a amd64 -n laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _`

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@
 sudo: 'required'
 
 # xenial is pretty old, but not as bad as trusty...
-#dist: xenial
+dist: xenial
 
-language: java
+#language: java
 
-jdk:
-  - oraclejdk8
+#jdk:
+#  - oraclejdk8
 
 # have the docker service set up (we'll
 # update it later)
@@ -25,7 +25,7 @@ addons:
 # installation scripts
 before_install:
   - './.travis/main.sh'
-  #- './.travis/setup_emulation.sh'
+  - './.travis/setup_emulation.sh'
 
 #install:
 #  - python2 bootstrap.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,24 @@ addons:
 
 jobs:
   include:
+    - stage: preinstall
+      name: prebuild amd64
+      before_install:
+        - './.travis/main.sh'
+        - './.travis/setup_emulation.sh'
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    - stage: preinstall
+      name: prebuild arm7
+      before_install:
+        - './.travis/main.sh'
+        - './.travis/setup_emulation.sh'
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
     - stage: install
       name: build amd64
       # prepare the machine before any code
@@ -47,9 +65,10 @@ jobs:
       #  - python2 bootstrap.py --testing
 
       script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         # build/push an intermediate container
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        #- .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        #- .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
         # build the image itself
         - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
 
@@ -66,7 +85,6 @@ jobs:
         #    docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
         #    ./.travis/build-docker.sh -p ;
         #  fi
-        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
     - stage: install
       name: build arm7

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,8 @@ jobs:
 
       script:
         # build/push an intermediate container
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -f Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -f Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
         # build the image itself
         - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
         - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
         - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
     - stage: preinstall
-      name: prebuild arm7
+      name: prebuild arm32v7
       before_install:
         - './.travis/main.sh'
         - './.travis/setup_emulation.sh'
@@ -49,6 +49,16 @@ jobs:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
         - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    - stage: preinstall
+      name: prebuild arm64v8
+      before_install:
+        - './.travis/main.sh'
+        - './.travis/setup_emulation.sh'
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - .travis/bootstrap_image.sh -u arm64v8 -r python -t 2.7-buster -a arm8 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u arm64v8 -r python -t 2.7-buster -a arm8 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+
     ## actually install our software on top of the above
     - stage: install
       name: build amd64
@@ -81,7 +91,7 @@ jobs:
         #  fi
         - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
     - stage: install
-      name: build arm7
+      name: build arm32v7
       before_install:
         - './.travis/main.sh'
         - './.travis/setup_emulation.sh'
@@ -90,6 +100,18 @@ jobs:
       after_success:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    - stage: install
+      name: build arm64v8
+      before_install:
+        - './.travis/main.sh'
+        - './.travis/setup_emulation.sh'
+      script:
+        - .travis/bootstrap_image.sh -u laroque -r volttron-docker -t deps-`echo ${TRAVIS_BRANCH} | tr / _`-arm -a arm8 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+      after_success:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - .travis/bootstrap_image.sh -u arm64v8 -r debian -t 10 -a arm8 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
+
+    ## assemble a manifest from the above
     - stage: manifest
       before_install:
         - './.travis/main.sh'

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,10 @@ jobs:
         - './.travis/main.sh'
         - './.travis/setup_emulation.sh'
       script:
-        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
       after_success:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
     - stage: manifest
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     script:
       ##- 'ci-integration/run-tests.sh'
       #- './.travis/build-docker.sh -b'
-      - .travis/bootstrap_image.sh -u amd64 -r debian -t 9 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+      - .travis/bootstrap_image.sh -u amd64 -r debian -t 10 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
 
     # only execute the following instructions in
     # the case of a success (failing at this point

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ jobs:
     #  - python2 bootstrap.py --testing
 
     script:
-      #- 'ci-integration/run-tests.sh'
-      - './.travis/build-docker.sh -b'
+      ##- 'ci-integration/run-tests.sh'
+      #- './.travis/build-docker.sh -b'
       - .travis/bootstrap_image.sh -u amd64 -r debian -t 9 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
 
     # only execute the following instructions in

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ sudo: 'required'
 # xenial is pretty old, but not as bad as trusty...
 dist: xenial
 
-#language: java
-
-#jdk:
-#  - oraclejdk8
-
 # have the docker service set up (we'll
 # update it later)
 services:
@@ -33,24 +28,24 @@ addons:
 jobs:
   include:
     ## a stage to take build a new base image with python dependencies included (this is slow on some architectures)
-    #- stage: preinstall
-    #  name: prebuild amd64
-    #  before_install:
-    #    - './.travis/main.sh'
-    #    - './.travis/setup_emulation.sh'
-    #  script:
-    #    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    #    - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
-    #    - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
-    #- stage: preinstall
-    #  name: prebuild arm7
-    #  before_install:
-    #    - './.travis/main.sh'
-    #    - './.travis/setup_emulation.sh'
-    #  script:
-    #    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    #    - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
-    #    - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    - stage: preinstall
+      name: prebuild amd64
+      before_install:
+        - './.travis/main.sh'
+        - './.travis/setup_emulation.sh'
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    - stage: preinstall
+      name: prebuild arm7
+      before_install:
+        - './.travis/main.sh'
+        - './.travis/setup_emulation.sh'
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
     ## actually install our software on top of the above
     - stage: install
       name: build amd64
@@ -60,17 +55,11 @@ jobs:
         - './.travis/main.sh'
         - './.travis/setup_emulation.sh'
 
-      #install:
-      #  - python2 bootstrap.py
-        # Installs testing toolkit
-        #- python2 bootstrap.py --crate
-      #  - python2 bootstrap.py --testing
-
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         # build/push an intermediate container
-        #- .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
-        #- .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
         # build the image itself
         - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
 
@@ -82,7 +71,7 @@ jobs:
       # and then `travis set ..` or go to the travis
       # page of your repository and then change the 
       # environment in the settings pannel.
-      after_success:
+      #after_success:
         #- if [[ "$TRAVIS_BRANCH" == "master" ]]; then
         #    docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
         #    ./.travis/build-docker.sh -p ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     script:
       #- 'ci-integration/run-tests.sh'
       - './.travis/build-docker.sh -b'
-      - .travis/bootstrap_image.sh -u amd64 -r debian -t 9 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _`
+      - .travis/bootstrap_image.sh -u amd64 -r debian -t 9 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
 
     # only execute the following instructions in
     # the case of a success (failing at this point

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 # make use of vm's
 sudo: 'required'
 
+# xenial is pretty old, but not as bad as trusty...
+dist: xenial
+
 language: java
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,21 @@ dist: xenial
 services:
   - docker
 
-# adding additional apt packages, required
-# for multi-architecture builds
+# adding additional apt packages
 addons:
   apt:
     packages:
       - qemu-user-static
+      # from the original main.sh
+      - realpath
+      - build-essential
+      - python
+      - python-pip
+      - python-dev
+      - openssl
+      - libssl-dev
+      - libevent-dev
+      - git
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 sudo: 'required'
 
 # xenial is pretty old, but not as bad as trusty...
-dist: xenial
+#dist: xenial
 
 language: java
 
@@ -25,7 +25,7 @@ addons:
 # installation scripts
 before_install:
   - './.travis/main.sh'
-  - './.travis/setup_emulation.sh'
+  #- './.travis/setup_emulation.sh'
 
 #install:
 #  - python2 bootstrap.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,8 @@ jobs:
       #  - python2 bootstrap.py --testing
 
       script:
-        ##- 'ci-integration/run-tests.sh'
-        #- './.travis/build-docker.sh -b'
-        - .travis/bootstrap_image.sh -u amd64 -r debian -t 10 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        #- .travis/bootstrap_image.sh -u amd64 -r debian -t 10 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
 
       # only execute the following instructions in
       # the case of a success (failing at this point
@@ -65,17 +64,17 @@ jobs:
         #    ./.travis/build-docker.sh -p ;
         #  fi
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - .travis/bootstrap_image.sh -u amd64 -r debian -t 10 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
     - stage: install
       name: build arm7
       before_install:
         - './.travis/main.sh'
         - './.travis/setup_emulation.sh'
       script:
-        - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u arm32v7 -r 2.7 -t 2.7 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
       after_success:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
     - stage: manifest
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,34 +23,36 @@ addons:
 
 jobs:
   include:
-    # prepare the machine before any code
-    # installation scripts
-    before_install:
-      - './.travis/main.sh'
-      - './.travis/setup_emulation.sh'
+    - stage: install
+      name: build amd64
+      # prepare the machine before any code
+      # installation scripts
+      before_install:
+        - './.travis/main.sh'
+        - './.travis/setup_emulation.sh'
 
-    #install:
-    #  - python2 bootstrap.py
-      # Installs testing toolkit
-      #- python2 bootstrap.py --crate
-    #  - python2 bootstrap.py --testing
+      #install:
+      #  - python2 bootstrap.py
+        # Installs testing toolkit
+        #- python2 bootstrap.py --crate
+      #  - python2 bootstrap.py --testing
 
-    script:
-      ##- 'ci-integration/run-tests.sh'
-      #- './.travis/build-docker.sh -b'
-      - .travis/bootstrap_image.sh -u amd64 -r debian -t 10 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+      script:
+        ##- 'ci-integration/run-tests.sh'
+        #- './.travis/build-docker.sh -b'
+        - .travis/bootstrap_image.sh -u amd64 -r debian -t 10 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
 
-    # only execute the following instructions in
-    # the case of a success (failing at this point
-    # won't mark the build as a failure).
-    # To have `DOCKER_USERNAME` and `DOCKER_PASSWORD`
-    # filled you need to either use `travis`' cli 
-    # and then `travis set ..` or go to the travis
-    # page of your repository and then change the 
-    # environment in the settings pannel.
-    after_success:
-      - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
-          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
-          ./.travis/build-docker.sh -p ;
-        fi
-
+      # only execute the following instructions in
+      # the case of a success (failing at this point
+      # won't mark the build as a failure).
+      # To have `DOCKER_USERNAME` and `DOCKER_PASSWORD`
+      # filled you need to either use `travis`' cli 
+      # and then `travis set ..` or go to the travis
+      # page of your repository and then change the 
+      # environment in the settings pannel.
+      after_success:
+        #- if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+        #    docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
+        #    ./.travis/build-docker.sh -p ;
+        #  fi
+        - .travis/bootstrap_image.sh -u amd64 -r debian -t 10 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,15 +49,15 @@ jobs:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
         - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
-    - stage: preinstall
-      name: prebuild arm64v8
-      before_install:
-        - './.travis/main.sh'
-        - './.travis/setup_emulation.sh'
-      script:
-        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - .travis/bootstrap_image.sh -u arm64v8 -r python -t 2.7-buster -a arm8 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
-        - .travis/bootstrap_image.sh -u arm64v8 -r python -t 2.7-buster -a arm8 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    #- stage: preinstall
+    #  name: prebuild arm64v8
+    #  before_install:
+    #    - './.travis/main.sh'
+    #    - './.travis/setup_emulation.sh'
+    #  script:
+    #    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    #    - .travis/bootstrap_image.sh -u arm64v8 -r python -t 2.7-buster -a arm8 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+    #    - .travis/bootstrap_image.sh -u arm64v8 -r python -t 2.7-buster -a arm8 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
 
     ## actually install our software on top of the above
     - stage: install
@@ -100,16 +100,16 @@ jobs:
       after_success:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
-    - stage: install
-      name: build arm64v8
-      before_install:
-        - './.travis/main.sh'
-        - './.travis/setup_emulation.sh'
-      script:
-        - .travis/bootstrap_image.sh -u laroque -r volttron-docker -t deps-`echo ${TRAVIS_BRANCH} | tr / _`-arm -a arm8 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
-      after_success:
-        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - .travis/bootstrap_image.sh -u arm64v8 -r debian -t 10 -a arm8 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    #- stage: install
+    #  name: build arm64v8
+    #  before_install:
+    #    - './.travis/main.sh'
+    #    - './.travis/setup_emulation.sh'
+    #  script:
+    #    - .travis/bootstrap_image.sh -u laroque -r volttron-docker -t deps-`echo ${TRAVIS_BRANCH} | tr / _`-arm -a arm8 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+    #  after_success:
+    #    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    #    - .travis/bootstrap_image.sh -u arm64v8 -r debian -t 10 -a arm8 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
 
     ## assemble a manifest from the above
     - stage: manifest
@@ -118,4 +118,5 @@ jobs:
         #- './.travis/setup_emulation.sh'
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        #- .travis/build_manifest.sh -a arm -a arm8 -a amd64 -n laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _`
         - .travis/build_manifest.sh -a arm -a amd64 -n laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _`

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,24 @@ language: java
 
 jdk:
   - oraclejdk8
-  
+
 # have the docker service set up (we'll
 # update it later)
 services:
-  - 'docker'
+  - docker
+
+# adding additional apt packages, required
+# for multi-architecture builds
+addons:
+  apt:
+    packages:
+      - qemu-user-static
 
 # prepare the machine before any code
 # installation scripts
 before_install:
   - './.travis/main.sh'
+  - './.travis/setup_emulation.sh'
 
 #install:
 #  - python2 bootstrap.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,5 @@ jobs:
         #    docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
         #    ./.travis/build-docker.sh -p ;
         #  fi
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - .travis/bootstrap_image.sh -u amd64 -r debian -t 10 -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ jobs:
         - './.travis/setup_emulation.sh'
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i volttron/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i volttron/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
     - stage: preinstall
       name: prebuild arm32v7
       before_install:
@@ -47,8 +47,8 @@ jobs:
         - './.travis/setup_emulation.sh'
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
-        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i volttron/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u arm32v7 -r python -t 2.7-buster -a arm7 -d Dockerfile.deps -i volttron/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
     #- stage: preinstall
     #  name: prebuild arm64v8
     #  before_install:
@@ -56,8 +56,8 @@ jobs:
     #    - './.travis/setup_emulation.sh'
     #  script:
     #    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    #    - .travis/bootstrap_image.sh -u arm64v8 -r python -t 2.7-buster -a arm8 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
-    #    - .travis/bootstrap_image.sh -u arm64v8 -r python -t 2.7-buster -a arm8 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    #    - .travis/bootstrap_image.sh -u arm64v8 -r python -t 2.7-buster -a arm8 -d Dockerfile.deps -i volttron/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+    #    - .travis/bootstrap_image.sh -u arm64v8 -r python -t 2.7-buster -a arm8 -d Dockerfile.deps -i volttron/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
 
     ## actually install our software on top of the above
     - stage: install
@@ -71,10 +71,10 @@ jobs:
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         # build/push an intermediate container
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i laroque/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i volttron/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -d Dockerfile.deps -i volttron/volttron-docker:deps-`echo ${TRAVIS_BRANCH} | tr / _` -p push
         # build the image itself
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -i volttron/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
 
       # only execute the following instructions in
       # the case of a success (failing at this point
@@ -89,27 +89,27 @@ jobs:
         #    docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
         #    ./.travis/build-docker.sh -p ;
         #  fi
-        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        - .travis/bootstrap_image.sh -u amd64 -r python -t 2.7-buster -a amd64 -i volttron/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
     - stage: install
       name: build arm32v7
       before_install:
         - './.travis/main.sh'
         - './.travis/setup_emulation.sh'
       script:
-        - .travis/bootstrap_image.sh -u laroque -r volttron-docker -t deps-`echo ${TRAVIS_BRANCH} | tr / _`-arm -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+        - .travis/bootstrap_image.sh -u volttron -r volttron-docker -t deps-`echo ${TRAVIS_BRANCH} | tr / _`-arm -a arm7 -i volttron/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
       after_success:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
+        - .travis/bootstrap_image.sh -u arm32v7 -r debian -t 10 -a arm7 -i volttron/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
     #- stage: install
     #  name: build arm64v8
     #  before_install:
     #    - './.travis/main.sh'
     #    - './.travis/setup_emulation.sh'
     #  script:
-    #    - .travis/bootstrap_image.sh -u laroque -r volttron-docker -t deps-`echo ${TRAVIS_BRANCH} | tr / _`-arm -a arm8 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
+    #    - .travis/bootstrap_image.sh -u volttron -r volttron-docker -t deps-`echo ${TRAVIS_BRANCH} | tr / _`-arm -a arm8 -i volttron/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p build
     #  after_success:
     #    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    #    - .travis/bootstrap_image.sh -u arm64v8 -r debian -t 10 -a arm8 -i laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
+    #    - .travis/bootstrap_image.sh -u arm64v8 -r debian -t 10 -a arm8 -i volttron/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _` -p push
 
     ## assemble a manifest from the above
     - stage: manifest
@@ -118,5 +118,5 @@ jobs:
         #- './.travis/setup_emulation.sh'
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        #- .travis/build_manifest.sh -a arm -a arm8 -a amd64 -n laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _`
-        - .travis/build_manifest.sh -a arm -a amd64 -n laroque/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _`
+        #- .travis/build_manifest.sh -a arm -a arm8 -a amd64 -n volttron/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _`
+        - .travis/build_manifest.sh -a arm -a amd64 -n volttron/volttron-docker:`echo ${TRAVIS_BRANCH} | tr / _`

--- a/.travis/Dockerfile.shim
+++ b/.travis/Dockerfile.shim
@@ -1,0 +1,9 @@
+ARG IMAGE_USER=amd64
+ARG IMAGE_REPO=debian
+ARG IMAGE_TAG=9
+
+FROM ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}
+
+# copy the local qemu interpreter layer
+# NOTE: this file is *not* provided in the repo, it needs to be installed via your package manager and copied here
+COPY this_qemu QEMU_TARGET_LOCATION

--- a/.travis/Dockerfile.shim
+++ b/.travis/Dockerfile.shim
@@ -1,8 +1,8 @@
-ARG img_user=amd64
-ARG img_repo=debian
-ARG img_tag=9
+ARG image_user=amd64
+ARG image_repo=debian
+ARG image_tag=9
 
-FROM ${img_user}/${img_repo}:${img_tag}
+FROM ${image_user}/${image_repo}:${image_tag}
 
 # copy the local qemu interpreter layer
 # NOTE: this file is *not* provided in the repo, it needs to be installed via your package manager and copied here

--- a/.travis/Dockerfile.shim
+++ b/.travis/Dockerfile.shim
@@ -1,8 +1,8 @@
-ARG IMAGE_USER=amd64
-ARG IMAGE_REPO=debian
-ARG IMAGE_TAG=9
+ARG img_user=amd64
+ARG img_repo=debian
+ARG img_tag=9
 
-FROM ${IMAGE_USER}/${IMAGE_REPO}:${IMAGE_TAG}
+FROM ${img_user}/${img_repo}:${img_tag}
 
 # copy the local qemu interpreter layer
 # NOTE: this file is *not* provided in the repo, it needs to be installed via your package manager and copied here

--- a/.travis/bootstrap_image.sh
+++ b/.travis/bootstrap_image.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+## conventional notes
+## - true comments that are not in-line start with double ## (commented out lines are single)
+## - local variables are lower_snake_case (leaves UPPER_SNAKE for environment stuff)
+## - echo statements that are just progress notes start with "-- "
+
+
+usage() {
+    echo -e "Usage: $0 \n"\
+         "    -u (user portion of emulation base image specification)\n"\
+         "    -r (repo portion of emulation base image specification)\n"\
+         "    -t (tag portion of emulation base image specification)\n" \
+         "    -i (user, repo, and base-tag of output image (arch is automatically appended)\n" \
+         "    -a (desired architecture, one of [arm7, amd64])"
+    exit 2
+}
+
+echo "-- parsing bootstrap base image options"
+
+if [[ $1 == "" ]]; then
+  usage
+fi
+while getopts u:r:t:i:a: option ; do
+  case $option in
+    u) # store user
+      if [[ $OPTARG == "" ]]; then
+        echo "user flag requires value"
+        exit 2
+      fi
+      image_user="$OPTARG"
+      ;;
+    r) # store repo
+      if [[ $OPTARG == "" ]]; then
+        echo "repo flag requires value"
+        exit 2
+      fi
+      image_repo="$OPTARG"
+      ;;
+    t) # store tag
+      if [[ $OPTARG == "" ]]; then
+        echo "tag flag requires value"
+        exit 2
+      fi
+      image_tag="$OPTARG"
+      ;;
+    i) # store output repo info
+      if [[ $OPTARG == "" ]]; then
+        echo "output image flag requires value"
+        exit 2
+      fi
+      output_image="$OPTARG"
+      ;;
+    a) # store target architecture
+      if [[ $OPTARG == "" ]]; then
+        echo "architecture flag requires value"
+        exit 2
+      fi
+      if [[ "amd64 arm7" =~ (^|[[:space:]])"$OPTARG"($|[[:space:]]) ]]; then
+        target_arch="$OPTARG"
+      else
+        echo "arch '${OPTARG}' not recognized"
+        usage
+      fi
+      ;;
+    *) # print usage
+      usage
+      ;;
+  esac
+done
+if [[ -z $image_user || -z $image_repo || -z $image_tag || -z $target_arch || -z $output_image ]]; then
+    echo "all arguments are required"
+    usage
+fi
+
+original_qemu_path=""
+case $target_arch in
+    amd64)
+        original_qemu_path="/usr/bin/qemu-x86_64-static"
+        architecture_img_suffix="amd64"
+        echo "-- set qemu vars for amd64"
+        ;;
+    arm7)
+        original_qemu_path="/usr/bin/qemu-arm-static"
+        architecture_img_suffix="arm"
+        echo "-- set qemu vars for arm7"
+        ;;
+esac
+
+dot_travis_path=`dirname $0`
+dot_travis_path=`readlink -e $dot_travis_path`
+
+set -x
+
+# bootstrap a custom base image with emulation
+cp $original_qemu_path ${dot_travis_path}/this_qemu
+sed "s#QEMU_TARGET_LOCATION#${original_qemu_path}#" $dot_travis_path/Dockerfile.shim > $dot_travis_path/Dockerfile
+docker build \
+    --build-arg image_user=$image_user \
+    --build-arg image_repo=$image_repo \
+    --build-arg image_tag=$image_tag \
+    -t local/emulation_base:latest \
+    -f $dot_travis_path/Dockerfile \
+    $dot_travis_path
+
+# build the arch-specific image on top of it
+docker build \
+    --build-arg img_user=local \
+    --build-arg img_repo=emulation_base \
+    --build-arg img_tag=latest \
+    -t ${output_image}-${architecture_img_suffix} \
+    .
+docker push ${output_image}-${architecture_img_suffix}
+
+set +x

--- a/.travis/bootstrap_image.sh
+++ b/.travis/bootstrap_image.sh
@@ -108,7 +108,7 @@ set -x
 
 case $phase_action in
     build)
-        set -o
+        set -e
         # bootstrap a custom base image with emulation
         cp $original_qemu_path ${dot_travis_path}/this_qemu
         sed "s#QEMU_TARGET_LOCATION#${original_qemu_path}#" $dot_travis_path/Dockerfile.shim > $dot_travis_path/Dockerfile

--- a/.travis/bootstrap_image.sh
+++ b/.travis/bootstrap_image.sh
@@ -126,7 +126,6 @@ case $phase_action in
             .
         ;;
     push)
-        echo "$DOCKERPASSWORD" | docker login -u $DOCKER_USERNAME --password-stdin
         docker push ${output_image}-${architecture_img_suffix}
         ;;
     *)

--- a/.travis/bootstrap_image.sh
+++ b/.travis/bootstrap_image.sh
@@ -85,6 +85,7 @@ while getopts u:r:t:i:a:p:d: option ; do
         exit 2
       fi
       dockerfile_path="$OPTARG"
+      ;;
     *) # print usage
       usage
       ;;

--- a/.travis/bootstrap_image.sh
+++ b/.travis/bootstrap_image.sh
@@ -119,9 +119,9 @@ case $phase_action in
             $dot_travis_path
         # build the arch-specific image on top of it
         docker build \
-            --build-arg img_user=local \
-            --build-arg img_repo=emulation_base \
-            --build-arg img_tag=latest \
+            --build-arg image_user=local \
+            --build-arg image_repo=emulation_base \
+            --build-arg image_tag=latest \
             -t ${output_image}-${architecture_img_suffix} \
             .
         ;;

--- a/.travis/bootstrap_image.sh
+++ b/.travis/bootstrap_image.sh
@@ -108,6 +108,7 @@ set -x
 
 case $phase_action in
     build)
+        set -o
         # bootstrap a custom base image with emulation
         cp $original_qemu_path ${dot_travis_path}/this_qemu
         sed "s#QEMU_TARGET_LOCATION#${original_qemu_path}#" $dot_travis_path/Dockerfile.shim > $dot_travis_path/Dockerfile

--- a/.travis/bootstrap_image.sh
+++ b/.travis/bootstrap_image.sh
@@ -13,7 +13,7 @@ usage() {
          "    -r (repo portion of emulation base image specification)\n"\
          "    -t (tag portion of emulation base image specification)\n" \
          "    -i (user, repo, and base-tag of output image (arch is automatically appended)\n" \
-         "    -a (desired architecture, one of [arm7, amd64])\n" \
+         "    -a (desired architecture, one of [arm7, arm8, amd64])\n" \
          "    -p (desire phase, one of [build, push])\n" \
          "    -d (name of Dockerfile to build - default is Dockerfile)"
     exit 2
@@ -60,7 +60,7 @@ while getopts u:r:t:i:a:p:d: option ; do
         echo "architecture flag requires value"
         exit 2
       fi
-      if [[ "amd64 arm7" =~ (^|[[:space:]])"$OPTARG"($|[[:space:]]) ]]; then
+      if [[ "amd64 arm7 arm8" =~ (^|[[:space:]])"$OPTARG"($|[[:space:]]) ]]; then
         target_arch="$OPTARG"
       else
         echo "arch '${OPTARG}' not recognized"
@@ -107,6 +107,11 @@ case $target_arch in
         original_qemu_path="/usr/bin/qemu-arm-static"
         architecture_img_suffix="arm"
         echo "-- set qemu vars for arm7"
+        ;;
+    arm8)
+        original_qemu_path="/usr/bin/qemu-aarch64-static"
+        architecture_img_suffix="arm64"
+        echo "-- set qemu vars for arm64-v8"
         ;;
 esac
 

--- a/.travis/bootstrap_image.sh
+++ b/.travis/bootstrap_image.sh
@@ -126,7 +126,7 @@ case $phase_action in
             .
         ;;
     push)
-        docker login -u $DOCKER_PASSWORD -p $DOCKER_PASSWORD
+        echo "$DOCKERPASSWORD" | docker login -u $DOCKER_USERNAME --password-stdin
         docker push ${output_image}-${architecture_img_suffix}
         ;;
     *)

--- a/.travis/bootstrap_image.sh
+++ b/.travis/bootstrap_image.sh
@@ -14,7 +14,8 @@ usage() {
          "    -t (tag portion of emulation base image specification)\n" \
          "    -i (user, repo, and base-tag of output image (arch is automatically appended)\n" \
          "    -a (desired architecture, one of [arm7, amd64])\n" \
-         "    -p (desire phase, one of [build, push])"
+         "    -p (desire phase, one of [build, push])\n" \
+         "    -d (name of Dockerfile to build - default is Dockerfile)"
     exit 2
 }
 
@@ -23,7 +24,8 @@ echo "-- parsing bootstrap base image options"
 if [[ $1 == "" ]]; then
   usage
 fi
-while getopts u:r:t:i:a:p: option ; do
+dockerfile_path="Dockerfile"
+while getopts u:r:t:i:a:p:d: option ; do
   case $option in
     u) # store user
       if [[ $OPTARG == "" ]]; then
@@ -77,6 +79,12 @@ while getopts u:r:t:i:a:p: option ; do
         usage
       fi
       ;;
+    d) # update dockerfile_path
+      if [[ $OPTARG == "" ]]; then
+        echo "dockerfile_path flag requires value"
+        exit 2
+      fi
+      dockerfile_path="$OPTARG"
     *) # print usage
       usage
       ;;
@@ -125,6 +133,7 @@ case $phase_action in
             --build-arg image_repo=emulation_base \
             --build-arg image_tag=latest \
             -t ${output_image}-${architecture_img_suffix} \
+            -f ${dockerfile_path} \
             .
         ;;
     push)

--- a/.travis/bootstrap_image.sh
+++ b/.travis/bootstrap_image.sh
@@ -5,6 +5,7 @@
 ## - local variables are lower_snake_case (leaves UPPER_SNAKE for environment stuff)
 ## - echo statements that are just progress notes start with "-- "
 
+set -o
 
 usage() {
     echo -e "Usage: $0 \n"\

--- a/.travis/build_manifest.sh
+++ b/.travis/build_manifest.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+usage() {
+    echo -e "Usage: $0 \n"\
+        "    -a architecture (name of an architecture annotcation to add to the manifest\n"\
+        "\n"\
+        "Creates a docker manifest with a provided name and tag (-n) from a\n"
+        "set of images for different architectures. Each image is expected\n"
+        "to have the same name and tag, with the tag suffixed by '-<arch>'\n"
+        "where <arch> is the docker-recognized name of the architecture\n"
+        ""
+    exit 2
+}
+
+if [[ $1 == "" ]]; then
+  usage
+fi
+
+architectures=""
+manifest_name=""
+
+# parse the arguments
+while getopts a:n: option ; do
+  case $option in
+    a) # store architectures
+      if [[ $OPTARG == "" ]]; then
+        echo "architecture flag requries a value"
+        exit 2
+      fi
+      architectures="$architectures $OPTARG"
+      ;;
+    n) # store the manifest name (image & tag)
+      if [[ $OPTARG == "" ]]; then
+        echo "name flag requries a value"
+        exit 2
+      fi
+      manifest_name=$OPTARG
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+# check required flags were received
+if [[ $manifest_name == "" ]]; then
+  echo "the name flag is required"
+  usage
+fi
+if [[ $architectures == "" ]]; then
+  echo "at least one architecture must be passed with the -a flag"
+  usage
+fi
+
+# build and populate the manifest
+set -o
+images_list=""
+for a in $architectures
+do
+    images_list="$images_list ${manifest_name}-${a}"
+done
+#echo "images list is: $images_list"
+docker manifest create $manifest_name $images_list
+for a in $architectures
+do
+    docker manifest annotate $manifest_name ${manifest_name}-${a} --arch $a
+done
+should run:\n docker manifest push $manifest_name
+set +o

--- a/.travis/build_manifest.sh
+++ b/.travis/build_manifest.sh
@@ -53,7 +53,7 @@ if [[ $architectures == "" ]]; then
 fi
 
 # build and populate the manifest
-set -o
+set -ex
 images_list=""
 for a in $architectures
 do
@@ -65,5 +65,5 @@ for a in $architectures
 do
     docker manifest annotate $manifest_name ${manifest_name}-${a} --arch $a
 done
-should run:\n docker manifest push $manifest_name
-set +o
+docker manifest push $manifest_name
+set +ex

--- a/.travis/main.sh
+++ b/.travis/main.sh
@@ -2,6 +2,7 @@
 
 # Set an option to exit immediately if any error appears
 set -o errexit
+set -x
 
 # Main function that describes the behavior of the 
 # script. 

--- a/.travis/setup_emulation.sh
+++ b/.travis/setup_emulation.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+
+echo '{"experimental":true}' | sudo tee -a /etc/docker/daemon.json
+sudo service docker restart
+
+sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/.travis/setup_emulation.sh
+++ b/.travis/setup_emulation.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-
-echo '{"experimental":true}' | sudo tee -a /etc/docker/daemon.json
-sudo service docker restart
+## these are redundant with main.sh
+#echo '{"experimental":true}' | sudo tee -a /etc/docker/daemon.json
+#sudo service docker restart
 
 sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,9 @@ RUN set -eux; apt-get update; apt-get install -y --no-install-recommends \
     wget \
     curl \
     ca-certificates \
+    libffi-dev \
     && apt-get update && apt-get install -yf \
-    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && python get-pip.py \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN set -eux; apt-get update; apt-get install -y --no-install-recommends \
 
 RUN id -u $VOLTTRON_USER &>/dev/null || adduser --disabled-password --gecos "" $VOLTTRON_USER
 
-RUN mkdir /code && chown $VOLTTRON_USER.$VOLTTRON_USER /code \
+RUN mkdir -p /code && chown $VOLTTRON_USER.$VOLTTRON_USER /code \
   && echo "export PATH=/home/volttron/.local/bin:$PATH" > /home/volttron/.bashrc
 
 ############################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN set -eux; apt-get update; apt-get install -y --no-install-recommends \
     vim \
     tree \
     build-essential \
-    python-dev \
+    #python-dev \
     openssl \
     libssl-dev \
     libevent-dev \
@@ -38,8 +38,8 @@ RUN set -eux; apt-get update; apt-get install -y --no-install-recommends \
     ca-certificates \
     libffi-dev \
     && apt-get update && apt-get install -yf \
-    && curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python get-pip.py \
+    #&& curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    #&& python get-pip.py \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ENV RMQ_ROOT=${VOLTTRON_USER_HOME}/rabbitmq_server
 ENV RMQ_HOME=${RMQ_ROOT}/rabbitmq_server-3.7.7
 
 # --no-install-recommends \
+USER root
 RUN set -eux; apt-get update; apt-get install -y --no-install-recommends \
     procps \
     gosu \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN set -eux; apt-get update; apt-get install -y --no-install-recommends \
     vim \
     tree \
     build-essential \
-    #python-dev \
+    python-dev \
     openssl \
     libssl-dev \
     libevent-dev \
@@ -38,8 +38,8 @@ RUN set -eux; apt-get update; apt-get install -y --no-install-recommends \
     ca-certificates \
     libffi-dev \
     && apt-get update && apt-get install -yf \
-    #&& curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    #&& python get-pip.py \
+    && curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python get-pip.py \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ARG image_tag=buster
 
 FROM ${image_user}/${image_repo}:${image_tag} as volttron_base
 
+RUN echo "from ${image_user}/${image_repo}:${image_tag}"
+
 SHELL [ "bash", "-c" ]
 
 ENV OS_TYPE=debian

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,9 @@ FROM volttron_base AS volttron_core
 USER $VOLTTRON_USER
 
 # The following lines ar no longer necesary because of the copy command above.
-WORKDIR /code
-RUN git clone https://github.com/VOLTTRON/volttron -b ${VOLTTRON_GIT_BRANCH}
+#WORKDIR /code
+#RUN git clone https://github.com/VOLTTRON/volttron -b ${VOLTTRON_GIT_BRANCH}
+COPY --chown=volttron:volttron volttron /code/volttron
 
 WORKDIR /code/volttron
 RUN echo "staring requirements install at `date`"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG image_tag=buster
 
 FROM ${image_user}/${image_repo}:${image_tag} as volttron_base
 
-RUN echo "from ${image_user}/${image_repo}:${image_tag}"
+RUN cat /etc/os-release
 
 SHELL [ "bash", "-c" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN set -eux; apt-get update; apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 
-RUN adduser --disabled-password --gecos "" $VOLTTRON_USER
+RUN id -u $VOLTTRON_USER &>/dev/null || adduser --disabled-password --gecos "" $VOLTTRON_USER
 
 RUN mkdir /code && chown $VOLTTRON_USER.$VOLTTRON_USER /code \
   && echo "export PATH=/home/volttron/.local/bin:$PATH" > /home/volttron/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,11 @@ WORKDIR /code
 RUN git clone https://github.com/VOLTTRON/volttron -b ${VOLTTRON_GIT_BRANCH}
 
 WORKDIR /code/volttron
-RUN pip install --user -r requirements.txt && pip install -e . --user
+RUN echo "staring requirements install at `date`"
+RUN pip install --user -r requirements.txt
+RUN echo "requirements complete, installing package at `date`"
+RUN pip install -e . --user
+RUN echo "package installed at `date`"
 
 ############################################
 # RABBITMQ SPECIFIC INSTALLATION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM debian:buster as volttron_base
+ARG image_user=amd64
+ARG image_repo=debian
+ARG image_tag=buster
+
+FROM ${image_user}/${image_repo}:${image_tag} as volttron_base
 
 SHELL [ "bash", "-c" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ ARG image_tag=buster
 
 FROM ${image_user}/${image_repo}:${image_tag} as volttron_base
 
-RUN cat /etc/os-release
-
 SHELL [ "bash", "-c" ]
 
 ENV OS_TYPE=debian

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,0 +1,72 @@
+ARG image_user=amd64
+ARG image_repo=debian
+ARG image_tag=buster
+
+FROM ${image_user}/${image_repo}:${image_tag} as volttron_base
+
+SHELL [ "bash", "-c" ]
+
+ENV OS_TYPE=debian
+ENV DIST=buster
+ENV VOLTTRON_GIT_BRANCH=rabbitmq-volttron
+ENV VOLTTRON_USER_HOME=/home/volttron
+ENV VOLTTRON_HOME=${VOLTTRON_USER_HOME}/.volttron
+ENV CODE_ROOT=/code
+ENV VOLTTRON_ROOT=${CODE_ROOT}/volttron
+ENV VOLTTRON_USER=volttron
+ENV USER_PIP_BIN=${VOLTTRON_USER_HOME}/.local/bin
+ENV RMQ_ROOT=${VOLTTRON_USER_HOME}/rabbitmq_server
+ENV RMQ_HOME=${RMQ_ROOT}/rabbitmq_server-3.7.7
+
+# --no-install-recommends \
+RUN set -eux; apt-get update; apt-get install -y --no-install-recommends \
+    procps \
+    gosu \
+    vim \
+    tree \
+    build-essential \
+    python-dev \
+    openssl \
+    libssl-dev \
+    libevent-dev \
+    git \
+    gnupg \
+    dirmngr \
+    apt-transport-https \
+    wget \
+    curl \
+    ca-certificates \
+    libffi-dev \
+    && apt-get update && apt-get install -yf \
+    && curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python get-pip.py \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN adduser --disabled-password --gecos "" $VOLTTRON_USER
+
+RUN mkdir /code && chown $VOLTTRON_USER.$VOLTTRON_USER /code \
+  && echo "export PATH=/home/volttron/.local/bin:$PATH" > /home/volttron/.bashrc
+
+############################################
+# ENDING volttron_base image
+############################################
+
+FROM volttron_base AS volttron_core
+
+# Note I couldn't get variable expansion on the chown argument to work here
+# so must hard code the user.  Note this is a feature request for docker
+# https://github.com/moby/moby/issues/35018
+# COPY --chown=volttron:volttron . ${VOLTTRON_ROOT}
+
+USER $VOLTTRON_USER
+
+# The following lines ar no longer necesary because of the copy command above.
+#WORKDIR /code
+#RUN git clone https://github.com/VOLTTRON/volttron -b ${VOLTTRON_GIT_BRANCH}
+COPY --chown=volttron:volttron volttron /code/volttron
+
+WORKDIR /code/volttron
+RUN echo "staring requirements install at `date`"
+RUN pip install --user -r requirements.txt
+RUN echo "requirements complete, installing package at `date`"


### PR DESCRIPTION
Automatic build of volttron docker images and builds manifests for multiple architecture support.

# Notes
- the builds are very slow on non-x86; this is (at least in part) because pypi does not host wheels for arm architectures and so those have to be built for all dependencies
- partly in trying to work around the above, the build configuration is a bit more hacked together than i'd hoped
- it would probably be valuable to evaluate what all is installed with the build, is there a minimal build that a feature-complete build could be on top of? Is there another way to split up the build time?
