### PR TITLE
Fix bootstart script; add symlink in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN id -u $VOLTTRON_USER &>/dev/null || adduser --disabled-password --gecos "" $
 RUN mkdir -p /code && chown $VOLTTRON_USER.$VOLTTRON_USER /code \
   && echo "export PATH=/home/volttron/.local/bin:$PATH" > /home/volttron/.bashrc
 
+RUN ln -s /usr/bin/pip3 /usr/bin/pip
 ############################################
 # ENDING volttron_base image
 ############################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN set -eux; apt-get update; apt-get install -y --no-install-recommends \
     python3-dev \
     python3-pip \
     python3-setuptools \
+    python3-wheel \
     openssl \
     libssl-dev \
     libevent-dev \
@@ -47,7 +48,6 @@ RUN id -u $VOLTTRON_USER &>/dev/null || adduser --disabled-password --gecos "" $
 RUN mkdir -p /code && chown $VOLTTRON_USER.$VOLTTRON_USER /code \
   && echo "export PATH=/home/volttron/.local/bin:$PATH" > /home/volttron/.bashrc
 
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
 ############################################
 # ENDING volttron_base image
 ############################################
@@ -58,6 +58,8 @@ FROM volttron_base AS volttron_core
 # so must hard code the user.  Note this is a feature request for docker
 # https://github.com/moby/moby/issues/35018
 # COPY --chown=volttron:volttron . ${VOLTTRON_ROOT}
+
+RUN ln -s /usr/bin/pip3 /usr/bin/pip
 
 USER $VOLTTRON_USER
 

--- a/core/bootstart.sh
+++ b/core/bootstart.sh
@@ -11,7 +11,8 @@ printenv
 
 python3 /startup/setup-platform.py
 setup_return=$?
-if [[ $setup_return ]]; then
+
+if [[ $setup_return -ne 0 ]]; then
     echo "error running setup-platform.py"
     exit $setup_return
 fi


### PR DESCRIPTION
What is the change?

* Fix if-statement in bootstart.sh
* Add symlink for pip3 in Dockerfile

Why is it needed?

* To make bootstart.sh properly return error message on non-zero return value
* To allow Dockerfile to execute `pip` commands using pip3 since the base image (Debian Buster) has default pip set to pip

How tested?

I first built the image and then ran the script locally on my VM (Ubuntu 18) and was able to get the script to complete instead of stopping at the error message.