### PR TITLE
Fix bugs in setup-platform; update platform_config and volttron submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The VOLTTRON container when created is just a blank container with no agents.  N
 The `platform_config.yml` file has two sections: `config`, which configures the main instance and populate's the main config file ($VOLTTRON_HOME/config), and `agents`, which contains a list of agents with references to configurations for them (note the frequent use of environment variables in this section).
 
 ## Main Configuration
-The main instance configuration is composed of key value pairs under a "config" key in the `platofrom_config.yml` file.
+The main instance configuration is composed of key value pairs under a "config" key in the `platform_config.yml` file.
 For example, the `vip-address` and `bind-web-address` would be populated using the following partial file:
 ``` yaml
 # Properties to be added to the root config file:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,44 @@ Similarly, changes made from the host are reflect in the container.
 The image features gosu, which allows the non-root user executing the volttron platform inside the container to have the same UID as the host user running the container on the host system.
 In conjunction with volume mounting of the directory, this ensures that file ownership and permissions in `VOLTTRON_HOME` match the host user, avoiding cases were root in the container leaves files inaccessible to a user without sudo permissions on the host.
 
+# Prerequisites
+
+* Docker
+* Docker-compose
+
+If you need to install docker and/or docker-compose, you can use the script in this repo. From the root level, execute the following command:
+
+```bash
+$ ./docker_install_ubuntu.sh
+```
+
+# Quickstart using Docker-Compose
+
+To create the container and start using the platform on the container, run the following command from the command line. Ensure that you are in the root level of the directory.
+
+``` bash
+$ docker-compose up
+
+# If you want to run the container in the background, you can use the detach flag:
+$ docker-compose up --detach
+
+# To look inside the container
+$ docker-compose exec volttron bash 
+
+# To stop the container
+$ docker-compose stop 
+
+# To start the container after it's been stopped
+$ docker-compose start 
+
+# To get a list of all containers created from docker-compose
+$ docker-compose ps
+```
+
+Once the container is fully created, open http://0.0.0.0:8080 on a browser to use the Volttron Web Interface. 
+
+
+
 # Platform Initialization
 
 The VOLTTRON container when created is just a blank container with no agents.  Now there is an initialization routine available within the docker container to allow the installation of agents before launching of the instance.  To do this one will mount a `platform_config.yml` file to `/platform_config.yml` within the container. One is also likely to need to mount agent configurations (specified in the `platform_config.yml` file), into the container. The recommended way to do this is through a `docker-compose.yml` file.  An example of this is included in this repository, based on the one in the [volttron-fuel-cells repo](https://github.com/VOLTTRON/volttron-fuel-cells/).
@@ -83,19 +121,15 @@ Agents within the `platform_config.yml` file are created sequentailly, it can ta
 
 # Local Development
 
-To build and test this image locally, you will need to install docker on Ubuntu, 
+To build and test this image locally, make any changes on the Dockerfile,
 build the image locally, and then create the container. 
 
-Step 1. Install docker using the script below: 
-```
-$ ./docker_install_ubuntu.sh
-```
-Step 2. Build the image:
+Step 1. Build the image:
 ```
 $ docker build -t volttron_local .
 ```
 
-Step 3. Run the container:
+Step 2. Run the container:
 ```
 $ docker run \
 -e LOCAL_USER_ID=$UID \
@@ -106,7 +140,8 @@ $ docker run \
 -it volttron_local
 ``` 
 
-Step 4. Once the container is started and running, open http://0.0.0.0:8080 on a browser to view the Volttron web platform interface.
+Step 3. Once the container is started and running, open http://0.0.0.0:8080 on a browser to view the Volttron web platform interface.
+
 # Raw Container Usage
 
 ``` bash

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This image provides a reproducible way to install VOLTTRON within a docker container.
 By using a volume mount of the `VOLTTRON_HOME` directory, runtime changes made by the platform are visible on the host and are preserved across instances of the container.
-Similarly, changes made from the host are reflect in the container.
-The image features gosu, which allows the non-root user executing the volttron platform inside the container to have the same UID as the host user running the container on the host system.
-In conjunction with volume mounting of the directory, this ensures that file ownership and permissions in `VOLTTRON_HOME` match the host user, avoiding cases were root in the container leaves files inaccessible to a user without sudo permissions on the host.
+Similarly, changes made from the host are reflected in the container.
+The image uses the utility [gosu](https://github.com/tianon/gosu), which allows the non-root user executing the volttron platform inside the container to have the same UID as the host user running the container on the host system.
+In conjunction with volume mounting of the directory, this ensures that file ownership and permissions in `VOLTTRON_HOME` match the host user, avoiding cases where root in the container leaves files inaccessible to a user without sudo permissions on the host.
 
 # Prerequisites
 
@@ -19,22 +19,6 @@ If you need to install docker and/or docker-compose, you can use the script in t
 $ ./docker_install_ubuntu.sh
 ```
 
-## Gotcha
-This repo has a directory called 'volttron', which contains the volttron codebase. In other words, this repo contains another repo in a subfolder. 
-When you initially clone this repo, the 'volttron' directory is empty. This directory contains the volttron codebase used to create the volttron platform. Before creating the container, you must pull in volttron from the official volttron repo using the following git command:
-
-```bash
-# Ensure that you are in the `volttron directory` 
-# Clones https://github.com/VOLTTRON/volttron.git into the 'volttron' directory
-$ git submodule update --init --recursive
-```
-
-To get the latest volttron from the `develop` branch, execute the following command:
-
-```bash 
-# Ensure that you are in the `volttron directory`
-$ git pull origin develop
-```
 
 # Quickstart using Docker-Compose
 
@@ -43,7 +27,7 @@ To create the container and start using the platform on the container, run the f
 ``` bash
 $ docker-compose up
 
-# If you want to run the container in the background, you can use the detach flag:
+# To run the container in the background:
 $ docker-compose up --detach
 
 # To look inside the container
@@ -71,7 +55,7 @@ The `platform_config.yml` file has two sections: `config`, which configures the 
 
 ## Main Configuration
 The main instance configuration is composed of key value pairs under a "config" key in the `platofrom_config.yml` file.
-As an example, the `vip-address` and `bind-web-address` would be populated using the following partial file:
+For example, the `vip-address` and `bind-web-address` would be populated using the following partial file:
 ``` yaml
 # Properties to be added to the root config file:
 # - the properties should be ingestable for volttron
@@ -87,7 +71,7 @@ config:
 ```
 
 ## Agent Configuration
-The agent configuration section is under a top-level key "agents" and contains several layers of nested key-value mappings.
+The agent configuration section is under a top-level key called "agents". This top-level key contains several layers of nested key-value mappings.
 The top level of the section is keyed with the names of the desired agents, which are used as the identity of those agents within the platform.
 For each agent key, there is a further mapping which must contain a `source` key and may contain either or both a `config` and/or `config_store` key; the values are strings representing resolvable paths.
 An example follows at the end of this section.
@@ -134,14 +118,34 @@ agents:
 ```
 
 ## Other Notes
-Agents within the `platform_config.yml` file are created sequentailly, it can take several seconds for each to spin up and be visible via `vctl` commands.
+Agents within the `platform_config.yml` file are created sequentially, it can take several seconds for each to spin up and be visible via `vctl` commands.
 
-# Local Development
+# Building Image Locally
 
-To build and test this image locally, make any changes on the Dockerfile,
-build the image locally, and then create the container. 
+## Prerequisite
+
+This repo has a directory called 'volttron', which contains the volttron codebase. In other words, this repo contains another repo in a subfolder. 
+When you initially clone this repo, the 'volttron' directory is empty. This directory contains the volttron codebase used to create the volttron platform. 
+Before creating the container, you must pull in volttron from the [official volttron repo](https://github.com/VOLTTRON/volttron) using the following git command:
+
+```bash
+# Clones https://github.com/VOLTTRON/volttron.git into the 'volttron' directory
+$ git submodule update --init --recursive
+```
+
+To get the latest volttron from the `develop` branch from the volttron repo, execute the following command:
+
+```bash 
+# Ensure that you are in the `volttron` folder
+$ git pull origin develop
+```
+
+## How to build locally
+
+To build and test this image locally, follow the steps below:
 
 Step 1. Build the image:
+
 ```
 $ docker build -t volttron_local .
 ```
@@ -158,6 +162,7 @@ $ docker run \
 ``` 
 
 Step 3. Once the container is started and running, open http://0.0.0.0:8080 on a browser to view the Volttron web platform interface.
+
 
 # Raw Container Usage
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # Introduction
 
-This image provides a reproducable way to install VOLTTRON within a docker container.
+This image provides a reproducible way to install VOLTTRON within a docker container.
 By using a volume mount of the `VOLTTRON_HOME` directory, runtime changes made by the platform are visible on the host and are preserved across instances of the container.
 Similarly, changes made from the host are reflect in the container.
 The image features gosu, which allows the non-root user executing the volttron platform inside the container to have the same UID as the host user running the container on the host system.
-In conjection with volume mounting of the directory, this ensures that file ownership and permissions in `VOLTTRON_HOME` match the host user, avoiding cases were root in the container leaves files inaccessible to a user without sudo permissions on the host.
+In conjunction with volume mounting of the directory, this ensures that file ownership and permissions in `VOLTTRON_HOME` match the host user, avoiding cases were root in the container leaves files inaccessible to a user without sudo permissions on the host.
 
 # Platform Initialization
 
@@ -79,8 +79,34 @@ agents:
 ```
 
 ## Other Notes
-agents within the `platform_config.yml` file are created sequentailly, it can take several seconds for each to spin up and be visible via `vctl` commands.
+Agents within the `platform_config.yml` file are created sequentailly, it can take several seconds for each to spin up and be visible via `vctl` commands.
 
+# Local Development
+
+To build and test this image locally, you will need to install docker on Ubuntu, 
+build the image locally, and then create the container. 
+
+Step 1. Install docker using the script below: 
+```
+$ ./docker_install_ubuntu.sh
+```
+Step 2. Build the image:
+```
+$ docker build -t volttron_local .
+```
+
+Step 3. Run the container:
+```
+$ docker run \
+-e LOCAL_USER_ID=$UID \
+-e CONFIG=/home/volttron/configs \
+-v $HOME/volttron-docker/configs:/home/volttron/configs \
+-v $HOME/volttron-docker/platform_config.yml:/platform_config.yml \
+-p 8080:8080 \
+-it volttron_local
+``` 
+
+Step 4. Once the container is started and running, open http://0.0.0.0:8080 on a browser to view the Volttron web platform interface.
 # Raw Container Usage
 
 ``` bash

--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ If you need to install docker and/or docker-compose, you can use the script in t
 $ ./docker_install_ubuntu.sh
 ```
 
+## Gotcha
+This repo has a directory called 'volttron', which contains the volttron codebase. In other words, this repo contains another repo in a subfolder. 
+When you initially clone this repo, the 'volttron' directory is empty. This directory contains the volttron codebase used to create the volttron platform. Before creating the container, you must pull in volttron from the official volttron repo using the following git command:
+
+```bash
+# Ensure that you are in the `volttron directory` 
+# Clones https://github.com/VOLTTRON/volttron.git into the 'volttron' directory
+$ git submodule update --init --recursive
+```
+
+To get the latest volttron from the `develop` branch, execute the following command:
+
+```bash 
+# Ensure that you are in the `volttron directory`
+$ git pull origin develop
+```
+
 # Quickstart using Docker-Compose
 
 To create the container and start using the platform on the container, run the following command from the command line. Ensure that you are in the root level of the directory.

--- a/core/setup-platform.py
+++ b/core/setup-platform.py
@@ -42,6 +42,16 @@ with open(platform_config) as cin:
     platform_cfg = config['config']
 
 print("Platform instance name set to: {}".format(platform_cfg.get('instance-name')))
+
+bind_web_address = platform_cfg.get("bind-web-address", None)
+if bind_web_address is not None:
+    print(f"Platform bind web address set to: {bind_web_address}")
+    from volttron.requirements import extras_require as extras
+    install_cmd = extras.get("web", None)
+    print(f"Installing packages for web platform: {install_cmd}")
+    if install_cmd is not None:
+        subprocess.check_call(install_cmd)
+
 envcpy = os.environ.copy()
 
 # Create the main volttron config file
@@ -116,7 +126,7 @@ if need_to_install:
         sys.stdout.write("Processing identity: {}\n".format(identity))
         agent_cfg = None
         if "source" not in spec:
-            sys.stderr.write("Invalid souce for identity: {}\n".format(identity))
+            sys.stderr.write("Invalid source for identity: {}\n".format(identity))
             continue
 
         if "config" in spec and spec["config"]:
@@ -134,13 +144,13 @@ if need_to_install:
             continue
 
         # grab the priority from the system config file
-        priority = spec.get('priority', 50)
+        priority = spec.get('priority', '50')
 
-        install_cmd = ["python", INSTALL_PATH]
+        install_cmd = ["python3", INSTALL_PATH]
         install_cmd.extend(["--agent-source", agent_source])
         install_cmd.extend(["--vip-identity", identity])
         install_cmd.extend(["--start", "--priority", priority])
-        install_cmd.extend(["--agent-start-time", "5"])
+        install_cmd.extend(["--agent-start-time", "20"])
         install_cmd.append('--force')
         if agent_cfg:
             install_cmd.extend(["--config", agent_cfg])
@@ -169,6 +179,9 @@ if need_to_install:
                 subprocess.check_call(entry_cmd)
 
     # Stop running volttron now that it is setup.
+    sys.stdout.write("\n**************************************************\n")
+    sys.stdout.write("SHUTTING DOWN FROM SETUP-PLATFORM.PY\n")
+    sys.stdout.write("**************************************************\n")
     subprocess.call(["vctl", "shutdown", "--platform"])
 
     sleep(5)

--- a/core/setup-platform.py
+++ b/core/setup-platform.py
@@ -1,5 +1,4 @@
 import logging
-from shutil import copy
 import subprocess
 import os
 import sys
@@ -11,7 +10,7 @@ from volttron.platform.instance_setup import setup_rabbitmq_volttron
 
 logging.basicConfig(level=logging.DEBUG)
 
-# The environment variables must be set or we ahve big issues
+# The environment variables must be set or we have big issues
 VOLTTRON_ROOT = os.environ['VOLTTRON_ROOT']
 VOLTTRON_HOME = os.environ['VOLTTRON_HOME']
 VOLTTRON_CMD = "volttron"
@@ -46,10 +45,12 @@ print("Platform instance name set to: {}".format(platform_cfg.get('instance-name
 bind_web_address = platform_cfg.get("bind-web-address", None)
 if bind_web_address is not None:
     print(f"Platform bind web address set to: {bind_web_address}")
-    from volttron.requirements import extras_require as extras
-    install_cmd = extras.get("web", None)
-    print(f"Installing packages for web platform: {install_cmd}")
+    from requirements import extras_require as extras
+    web_plt_pack = extras.get("web", None)
+    install_cmd = ["pip3", "install"]
+    install_cmd.extend(web_plt_pack)
     if install_cmd is not None:
+        print(f"Installing packages for web platform: {web_plt_pack}")
         subprocess.check_call(install_cmd)
 
 envcpy = os.environ.copy()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,12 @@ version: '3'
 services:
   volttron:
     hostname: vc
+    build:
+      context: .
     image: volttron/volttron
     ports:
-       - 23916:22916
-       - 8080:8080
+      - 8080:8080
+      #- 23916:22916
       #- 8443:8443
       #- 6671:5671    # ampqs port
       #- 25671:15671  # management port
@@ -14,7 +16,4 @@ services:
       - ./configs:/home/volttron/configs
     environment:
       - CONFIG=/home/volttron/configs
-      - IGNORE_ENV_CHECK=1
       - LOCAL_USER_ID=1000
-
-#- LOCAL_USER_ID=1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: '3'
 services:
   volttron:
     hostname: vc
-    build:
-      context: .
-    image: volttron/volttron
+    image: bonicim/volttron-docker-dev:test
     ports:
       - 8080:8080
       #- 23916:22916

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   volttron:
     hostname: vc
-    image: bonicim/volttron-docker-dev:test
+    image: volttron/volttron:develop
     ports:
       - 8080:8080
       #- 23916:22916

--- a/platform_config.yml
+++ b/platform_config.yml
@@ -29,25 +29,22 @@ agents:
     source: $VOLTTRON_ROOT/services/core/VolttronCentral
     config: $VOLTTRON_ROOT/services/core/VolttronCentral/config
 
-  master.driver:
+  platform.driver:
     source: $VOLTTRON_ROOT/services/core/MasterDriverAgent
+    config_store:
+      fake.csv:
+        file: $VOLTTRON_ROOT/examples/configurations/drivers/fake.csv
+        type: --csv
+      devices/fake-campus/fake-building/fake-device:
+        file: $VOLTTRON_ROOT/examples/configurations/drivers/fake.config
 
   platform.agent:
     source: $VOLTTRON_ROOT/services/core/VolttronCentralPlatform
     config: $VOLTTRON_ROOT/services/core/VolttronCentralPlatform/config
 
-  historian:
+  platform.historian:
     source: $VOLTTRON_ROOT/services/core/SQLHistorian
     config: $CONFIG/historian.config
-
-  platform.driver:
-    source: $VOLTTRON_ROOT/services/core/MasterDriverAgent
-    config_store:
-      fake.csv:
-        file: $CONFIG/bacnet_example_config.csv
-        type: --csv
-      devices/PNNL/ANNEX:
-        file: $CONFIG/annex.config
 
   platform.actuator:
     source: $VOLTTRON_ROOT/services/core/ActuatorAgent

--- a/platform_config.yml
+++ b/platform_config.yml
@@ -49,8 +49,8 @@ agents:
       devices/PNNL/ANNEX:
         file: $CONFIG/annex.config
 
-#  platform.actuator:
-#    source: $VOLTTRON_ROOT/services/core/ActuatorAgent
+  platform.actuator:
+    source: $VOLTTRON_ROOT/services/core/ActuatorAgent
 #
 #  weather:
 #    source: $VOLTTRON_ROOT/examples/DataPublisher

--- a/platform_config.yml
+++ b/platform_config.yml
@@ -7,7 +7,7 @@ config:
   # For rabbitmq this should match the hostname specified in
   # in the docker compose file hostname field for the service.
   bind-web-address: http://0.0.0.0:8080
-  #volttron-central-address: https://vc:8443
+  volttron-central-address: http://0.0.0.0:8080
   instance-name: foobar
   message-bus: zmq
   # volttron-central-address: a different address
@@ -40,6 +40,15 @@ agents:
     source: $VOLTTRON_ROOT/services/core/SQLHistorian
     config: $CONFIG/historian.config
 
+  platform.driver:
+    source: $VOLTTRON_ROOT/services/core/MasterDriverAgent
+    config_store:
+      fake.csv:
+        file: $CONFIG/bacnet_example_config.csv
+        type: --csv
+      devices/PNNL/ANNEX:
+        file: $CONFIG/annex.config
+
 #  platform.actuator:
 #    source: $VOLTTRON_ROOT/services/core/ActuatorAgent
 #
@@ -54,12 +63,3 @@ agents:
 #  platform.bacnet_proxy:
 #    source: $VOLTTRON_ROOT/services/core/BACnetProxy
 #    config: $CONFIG/bacnet-proxy.json
-#  platform.driver:
-#    source: $VOLTTRON_ROOT/services/core/MasterDriverAgent
-#    config_store:
-#      fake.csv:
-#        file: $CONFIG/bacnet_example_config.csv
-#        type: --csv
-#      devices/PNNL/ANNEX:
-#        file: $CONFIG/annex.config
-


### PR DESCRIPTION
What is the change?
* Fix script errors for installing agents
* Add install web-based packages on bind-web-address
* Upate platform_config.yml

Why is it needed?
* To allow the Dockerfile to successfully build an image when docker run or docker-compose is used to create a container.

How tested?
I ran the following docker run command to build the container. 

```
$ docker run -e LOCAL_USER_ID=$UID -e CONFIG=/home/volttron/configs \ 
-v $HOME/develop/volttron-docker/configs:/home/volttron/configs \
-v $HOME/develop/volttron-docker/platform_config.yml:/platform_config.yml \ 
-p 8080:8080 \
-it volt_develop 
```

 Note that for the volttron submodule, I used the latest from develop; the image also requires an update to requirements.txt, which is noted in this PR https://github.com/VOLTTRON/volttron/pull/2468 