### PR TITLE
Modified to recursively change the owner of the volttron home

### DIFF
--- a/core/entrypoint.sh
+++ b/core/entrypoint.sh
@@ -34,8 +34,8 @@ fi
 
 # # Only need to change
 # if [ -z "${VOLTTRON_USER_HOME}" ]; then
-#   echo "chown volttron.volttron -R $VOLTTRON_USER_HOME"
-#   chown volttron.volttron -R ${VOLTTRON_USER_HOME}
+echo "chown volttron.volttron -R $VOLTTRON_USER_HOME"
+chown volttron.volttron -R ${VOLTTRON_USER_HOME}
 # fi
 
 # echo "cd to $VOLTTRON_USER_HOME"


### PR DESCRIPTION
This allows us to mount the volttron home from the filesystem.

The downside to this is that I am not sure we can use it for the secure container stuff.  Also, if the volttron-home becomes very large this could prove to take a bit of time.  That is why I commented it out originally.