### PR TITLE
Update Docker image for rmq and zmq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN echo "package installed at `date`"
 ############################################
 USER root
 RUN ./scripts/rabbit_dependencies.sh $OS_TYPE $DIST
+RUN python3 -m pip install gevent-pika
 
 RUN mkdir /startup $VOLTTRON_HOME && \
     chown $VOLTTRON_USER.$VOLTTRON_USER $VOLTTRON_HOME

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Before creating the container, you must pull in volttron from the [official volt
 $ git submodule update --init --recursive
 ```
 
-To get the latest volttron from the `develop` branch from the volttron repo, execute the following command:
+OPTIONAL: This repo uses a specific version of volttron based on the commit in the 'volttron' submodule. If you want to use the latest volttron from the `develop` 
+branch from the volttron repo, execute the following command (NOTE: this is not required):
 
 ```bash 
 # Ensure that you are in the `volttron` folder
@@ -151,40 +152,50 @@ $ docker build -t volttron_local .
 ```
 
 Step 2. Run the container:
+
 ```
+# Creates a docker container named "volttron1"; this container will be automatically removed when the container stops running
 $ docker run \
+--name volttron1 \
+--rm \
 -e LOCAL_USER_ID=$UID \
 -e CONFIG=/home/volttron/configs \
--v $HOME/volttron-docker/configs:/home/volttron/configs \
--v $HOME/volttron-docker/platform_config.yml:/platform_config.yml \
+-v "$(pwd)"/configs:/home/volttron/configs \
+-v "$(pwd)"/platform_config.yml:/platform_config.yml \
 -p 8080:8080 \
 -it volttron_local
 ``` 
 
-Step 3. Once the container is started and running, open http://0.0.0.0:8080 on a browser to view the Volttron web platform interface.
+Step 3. Once the container is started and running, set the master username and password on the Volttron Central Admin page at `http://localhost:8080/index.html`
 
+Step 4. To log in to Volttron Central, open a browser and login to the Volttron web interface: `http://localhost:8080/vc/index.html`
 
 # Raw Container Usage
 
 ``` bash
-# Retrieves and executes the volttron container.
-docker run -it volttron/volttron
+# Retrieves and creates a volttron container from the volttron/volttron:develop image on Volttron DockerHub
+$ docker run -it  -e LOCAL_USER_ID=$UID --name volttron1 --rm -d volttron/volttron:develop
 ```
 
 After entering the above command the shell will be within the volttron container as a user named volttron.
 
 ``` bash
-# starting the platform
-volttron -vv -l volttron.log&
+$ docker exec -itu volttron volttron1 bash
 
-# cd to volttron root
-cd $VOLTTRON_ROOT
+# check status of volttron platform
+$ vctl status
 
-# installing listener agent
-python scripts/core/make-listener
+# set environment variable, IGNORE_ENV_CHECK, to ignore virtual env in python
+$ export IGNORE_ENV_CHECK=1
 
-# see the log messages
-tail -f volttron.log
+# Install a ListenterAgent
+$ python3 scripts/install-agent.py -s examples/ListenerAgent --start
+
+# check status of volttron platform to verify ListenerAgent is installed
+$ vctl status
+
+# To Stop the container
+$ docker stop volttron1
 ```
 
 All the same functionality that one would have from a VOLTTRON command line is available through the container.

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ $ docker run \
 -it volttron_local
 ``` 
 
-Step 3. Once the container is started and running, set the master username and password on the Volttron Central Admin page at `http://localhost:8080/index.html`
+Step 3. Once the container is started and running, set the master username and password on the Volttron Central Admin page at `http://0.0.0.0:8080/index.html`
 
-Step 4. To log in to Volttron Central, open a browser and login to the Volttron web interface: `http://localhost:8080/vc/index.html`
+Step 4. To log in to Volttron Central, open a browser and login to the Volttron web interface: `http://0.0.0.0:8080/vc/index.html`
 
 # Raw Container Usage
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,16 @@ $ ./docker_install_ubuntu.sh
 # Quickstart using Docker-Compose
 
 To create the container and start using the platform on the container, run the following command from the command line. Ensure that you are in the root level of the directory.
+Note that there are two docker-compose files:
+* docker-compose.yml: creates a single Volttron instance with ZMQ message bus
+* docker-compose.yml: creates a single Volttron instance with RMQ message bus
 
 ``` bash
+# Creates Volttron instance with ZMQ message bus
 $ docker-compose up
 
-# To run the container in the background:
-$ docker-compose up --detach
+# To create a Volttron instance with RMQ message bus
+$ docker-compose -f docker-compose-rmq.yml up 
 
 # To look inside the container
 $ docker-compose exec volttron bash 
@@ -43,8 +47,13 @@ $ docker-compose start
 $ docker-compose ps
 ```
 
-Once the container is fully created, open http://0.0.0.0:8080 on a browser to use the Volttron Web Interface. 
+For Volttron instance using ZMQ message bus:
+* Set the master username and password on the Volttron Central Admin page at `http://0.0.0.0:8080/index.html` 
+* To log in to Volttron Central, open a browser and login to the Volttron web interface: `http://0.0.0.0:8080/vc/index.html`
 
+For Volttron instances using RMQ message bus:
+* Set the master username and password on the Volttron Central Admin page at `https://0.0.0.0:8080/index.html` 
+* To log in to Volttron Central, open a browser and login to the Volttron web interface: `https://0.0.0.0:8080/vc/index.html`
 
 
 # Platform Initialization

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ For Volttron instance using ZMQ message bus:
 * To log in to Volttron Central, open a browser and login to the Volttron web interface: `http://0.0.0.0:8080/vc/index.html`
 
 For Volttron instances using RMQ message bus:
-* Set the master username and password on the Volttron Central Admin page at `https://0.0.0.0:8080/index.html` 
-* To log in to Volttron Central, open a browser and login to the Volttron web interface: `https://0.0.0.0:8080/vc/index.html`
+* Set the master username and password on the Volttron Central Admin page at `https://0.0.0.0:8443/index.html` 
+* To log in to Volttron Central, open a browser and login to the Volttron web interface: `https://0.0.0.0:8443/vc/index.html`
 
 
 # Platform Initialization

--- a/configs/rabbitmq_config.yml
+++ b/configs/rabbitmq_config.yml
@@ -1,0 +1,40 @@
+# For details on the structure of rabbitmq.config, see https://volttron.readthedocs.io/en/develop/platform-features/message-bus/rabbitmq/rabbitmq-volttron.html#configuration
+
+# Although host parameter is required, it is not required for demo purposes because the parameter will be
+# overwritten by core/setup-platform.py with the hostname specified in docker-compose
+# host: vc
+
+# mandatory. certificate data used to create root ca certificate. Each volttron
+# instance must have unique common-name for root ca certificate
+certificate-data:
+  country: US
+  state: Washington
+  location: Richland
+  organization: PNNL
+  organization-unit: VOLTTRON Team
+  common-name: volttron1-root-ca # should match the common-name defined during the CA creation routine in core/setup-platform.py
+
+#
+# optional parameters for single instance setup
+#
+# virtual-host: 'volttron' # defaults to volttron
+
+# use the below four port variables if using custom rabbitmq ports
+# defaults to 5672
+# amqp-port: '5672'
+
+# defaults to 5671
+# amqp-port-ssl: '5671'
+
+# defaults to 15672
+# mgmt-port: '15672'
+
+# defaults to 15671
+# mgmt-port-ssl: '15671'
+
+# defaults to true
+# ssl: 'true'
+
+# defaults to ~/rabbitmq_server/rabbbitmq_server-3.7.7
+# overwritten by core/setup-platform.py with the RMQ_HOME env var defined in Dockerfile
+# rmq-home: "~/rabbitmq_server/rabbitmq_server-3.7.7"

--- a/core/setup-platform.py
+++ b/core/setup-platform.py
@@ -6,7 +6,8 @@ from shutil import copy
 import yaml
 from time import sleep
 
-from volttron.platform import get_home, set_home, certs
+from volttron.platform.agent.known_identities import MASTER_WEB
+from volttron.platform import set_home, certs
 from volttron.platform.instance_setup import setup_rabbitmq_volttron
 from volttron.utils import get_hostname
 
@@ -100,6 +101,16 @@ if platform_cfg.get('message-bus') == 'rmq':
         server_name, cert_type="server", fqdn=get_hostname()
     )
     crts.create_signed_cert_files(admin_client_name, cert_type="client")
+
+    name = f"{platform_cfg.get('instance-name')}.{MASTER_WEB}"
+    master_web_cert = os.path.join(VOLTTRON_HOME, 'certificates/certs/',
+                                   name + "-server.crt")
+    master_web_key = os.path.join(VOLTTRON_HOME, 'certificates/private/',
+                                  name + "-server.pem")
+    print("Writing ssl cert and key paths to config.")
+    with open(os.path.join(cfg_path), "a") as fout:
+        fout.write(f"web-ssl-cert = {master_web_cert}\n")
+        fout.write(f"web-ssl-key = {master_web_key}\n")
 
     if not config.get('rabbitmq-config'):
         sys.stderr.write("Invalid rabbit-config entry in platform configuration file.\n")

--- a/docker-compose-rmq.yml
+++ b/docker-compose-rmq.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  volttron:
+    container_name: volttron1
+    hostname: vc
+#    image: volttron/volttron:develop
+    # since I currently don't have access to the official volttron Dockerhub, I'm housing the Dockerfile image in my personal DHub account
+    image: bonicim/volttron:develop # see https://hub.docker.com/repository/docker/bonicim/volttron/tags?page=1&ordering=last_updated
+    ports:
+      - 8080:8080
+      #- 23916:22916
+      #- 8443:8443
+      #- 6671:5671    # ampqs port
+      #- 25671:15671  # management port
+    volumes:
+      - ./platform_config_rmq.yml:/platform_config.yml
+      - ./configs:/home/volttron/configs
+    environment:
+      - CONFIG=/home/volttron/configs
+      - LOCAL_USER_ID=1000

--- a/docker-compose-rmq.yml
+++ b/docker-compose-rmq.yml
@@ -2,16 +2,14 @@ version: '3'
 services:
   volttron:
     container_name: volttron1
-    hostname: vc
+    hostname: volttron1
 #    image: volttron/volttron:develop
     # since I currently don't have access to the official volttron Dockerhub, I'm housing the Dockerfile image in my personal DHub account
     image: bonicim/volttron:develop # see https://hub.docker.com/repository/docker/bonicim/volttron/tags?page=1&ordering=last_updated
     ports:
-      - 8080:8080
-      #- 23916:22916
-      #- 8443:8443
-      #- 6671:5671    # ampqs port
-      #- 25671:15671  # management port
+      # host_port:container_port
+      # http port for volttron central
+      - 8443:8443
     volumes:
       - ./platform_config_rmq.yml:/platform_config.yml
       - ./configs:/home/volttron/configs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,20 @@ services:
     hostname: vc
     image: volttron/volttron:develop
     ports:
+      # host_port:container_port
+
+      # http port for volttron central
       - 8080:8080
-      #- 23916:22916
+      # https port for volttron central
       #- 8443:8443
-      #- 6671:5671    # ampqs port
-      #- 25671:15671  # management port
+
+      #- 23916:22916
+
+      # rmq ampqs port
+      #- 5671:5671
+
+      # rmq mgmt ssl port
+      #- 15671:15671
     volumes:
       - ./platform_config.yml:/platform_config.yml
       - ./configs:/home/volttron/configs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3'
 services:
   volttron:
     hostname: vc
-    image: volttron/volttron:develop
+#    image: volttron/volttron:develop
+    # since I currently don't have access to the official volttron Dockerhub, I'm housing the Dockerfile in my personal DHub account
+    image: bonicim/volttron:develop
     ports:
       - 8080:8080
       #- 23916:22916

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: volttron1
     hostname: vc
 #    image: volttron/volttron:develop
-    # since I currently don't have access to the official volttron Dockerhub, I'm housing the Dockerfile in my personal DHub account
+    # since I currently don't have access to the official volttron Dockerhub, I'm housing the Dockerfile image in my personal DHub account
     image: bonicim/volttron:develop # see https://hub.docker.com/repository/docker/bonicim/volttron/tags?page=1&ordering=last_updated
     ports:
       - 8080:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
 version: '3'
 services:
   volttron:
+    container_name: volttron1
     hostname: vc
 #    image: volttron/volttron:develop
     # since I currently don't have access to the official volttron Dockerhub, I'm housing the Dockerfile in my personal DHub account
-    image: bonicim/volttron:develop
+    image: bonicim/volttron:develop # see https://hub.docker.com/repository/docker/bonicim/volttron/tags?page=1&ordering=last_updated
     ports:
       - 8080:8080
       #- 23916:22916

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,25 +2,14 @@ version: '3'
 services:
   volttron:
     container_name: volttron1
-    hostname: vc
+    hostname: volttron1
 #    image: volttron/volttron:develop
     # since I currently don't have access to the official volttron Dockerhub, I'm housing the Dockerfile image in my personal DHub account
     image: bonicim/volttron:develop # see https://hub.docker.com/repository/docker/bonicim/volttron/tags?page=1&ordering=last_updated
     ports:
       # host_port:container_port
-
       # http port for volttron central
       - 8080:8080
-      # https port for volttron central
-      #- 8443:8443
-
-      #- 23916:22916
-
-      # rmq ampqs port
-      #- 5671:5671
-
-      # rmq mgmt ssl port
-      #- 15671:15671
     volumes:
       - ./platform_config.yml:/platform_config.yml
       - ./configs:/home/volttron/configs

--- a/platform_config.yml
+++ b/platform_config.yml
@@ -6,10 +6,10 @@ config:
   vip-address: tcp://0.0.0.0:22916
   # For rabbitmq this should match the hostname specified in
   # in the docker compose file hostname field for the service.
-  bind-web-address: http://0.0.0.0:8080
+  bind-web-address: http://vc:8080
   volttron-central-address: http://0.0.0.0:8080
   instance-name: volttron1
-  message-bus: zmq
+  message-bus: zmq # allowed values: zmq, rmq
   # volttron-central-address: a different address
   # volttron-central-serverkey: a different key
 

--- a/platform_config.yml
+++ b/platform_config.yml
@@ -8,7 +8,7 @@ config:
   # in the docker compose file hostname field for the service.
   bind-web-address: http://0.0.0.0:8080
   volttron-central-address: http://0.0.0.0:8080
-  instance-name: foobar
+  instance-name: volttron1
   message-bus: zmq
   # volttron-central-address: a different address
   # volttron-central-serverkey: a different key
@@ -23,7 +23,7 @@ agents:
   # directory and will be used to install the agent.
   listener:
     source: $VOLTTRON_ROOT/examples/ListenerAgent
-    config: $CONFIG/listener.config # This is an empty element $CONFIG/listener.config
+    config: $CONFIG/listener.config
 
   volttron.central:
     source: $VOLTTRON_ROOT/services/core/VolttronCentral

--- a/platform_config.yml
+++ b/platform_config.yml
@@ -8,12 +8,12 @@ config:
   # in the docker compose file hostname field for the service.
   bind-web-address: http://0.0.0.0:8080
   volttron-central-address: http://0.0.0.0:8080
-  instance-name: foobar
+  instance-name: volttron1
   message-bus: zmq
   # volttron-central-address: a different address
   # volttron-central-serverkey: a different key
 
-#rabbitmq-config: $CONFIG/rabbitmq_config.yml
+rabbitmq-config: $CONFIG/rabbitmq_config.yml
 
 # Agents dictionary to install.  The key must be a valid
 # identity for the agent to be installed correctly.

--- a/platform_config.yml
+++ b/platform_config.yml
@@ -6,7 +6,7 @@ config:
   vip-address: tcp://0.0.0.0:22916
   # For rabbitmq this should match the hostname specified in
   # in the docker compose file hostname field for the service.
-  bind-web-address: http://vc:8080
+  bind-web-address: http://0.0.0.0:8080
   volttron-central-address: http://0.0.0.0:8080
   instance-name: volttron1
   message-bus: zmq # allowed values: zmq, rmq

--- a/platform_config_rmq.yml
+++ b/platform_config_rmq.yml
@@ -6,8 +6,8 @@ config:
   vip-address: tcp://0.0.0.0:22916
   # For rabbitmq this should match the hostname specified in
   # in the docker compose file hostname field for the service.
-  bind-web-address: https://0.0.0.0:8080
-  volttron-central-address: https://0.0.0.0:8080
+  bind-web-address: https://0.0.0.0:8443
+  volttron-central-address: https://0.0.0.0:8443
   instance-name: volttron1
   message-bus: rmq # allowed values: zmq, rmq
   # volttron-central-address: a different address

--- a/platform_config_rmq.yml
+++ b/platform_config_rmq.yml
@@ -6,12 +6,14 @@ config:
   vip-address: tcp://0.0.0.0:22916
   # For rabbitmq this should match the hostname specified in
   # in the docker compose file hostname field for the service.
-  bind-web-address: http://0.0.0.0:8080
-  volttron-central-address: http://0.0.0.0:8080
+  bind-web-address: https://0.0.0.0:8080
+  volttron-central-address: https://0.0.0.0:8080
   instance-name: volttron1
-  message-bus: zmq # allowed values: zmq, rmq
+  message-bus: rmq # allowed values: zmq, rmq
   # volttron-central-address: a different address
   # volttron-central-serverkey: a different key
+
+rabbitmq-config: $CONFIG/rabbitmq_config.yml
 
 # Agents dictionary to install.  The key must be a valid
 # identity for the agent to be installed correctly.


### PR DESCRIPTION
What's the change?
* Update Dockerfile and associated configs and entrypoint-related scripts
* Update volttron submodule commit
* Note: the Dockerfile image is also housed in my personal DHub account at: https://hub.docker.com/repository/docker/bonicim/volttron/tags?page=1&ordering=last_updated

Why is it needed?
* To create a public-facing Dockerfile so that end-users can use this repo's docker-compose.yml to create a single Volttron platform in Docker with either ZMQ or RMQ.

How tested?
For ZMQ, I ran `docker-compose up`. For RMQ, I ran `docker-compose -f docker-compose-rmq.yml up`. I watched the logs and opened up the web UI to setup the Admin and check the platform. 
