### PR TITLE
Update docker-compose, correct examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Before creating the container, you must pull in volttron from the [official volt
 $ git submodule update --init --recursive
 ```
 
-To get the latest volttron from the `develop` branch from the volttron repo, execute the following command:
+OPTIONAL: This repo uses a specific version of volttron based on the commit in the 'volttron' submodule. If you want to use the latest volttron from the `develop` 
+branch from the volttron repo, execute the following command (NOTE: this is not required):
 
 ```bash 
 # Ensure that you are in the `volttron` folder
@@ -151,40 +152,50 @@ $ docker build -t volttron_local .
 ```
 
 Step 2. Run the container:
+
 ```
+# Creates a docker container named "volttron1"; this container will be automatically removed when the container stops running
 $ docker run \
+--name volttron1 \
+--rm \
 -e LOCAL_USER_ID=$UID \
 -e CONFIG=/home/volttron/configs \
--v $HOME/volttron-docker/configs:/home/volttron/configs \
--v $HOME/volttron-docker/platform_config.yml:/platform_config.yml \
+-v "$(pwd)"/configs:/home/volttron/configs \
+-v "$(pwd)"/platform_config.yml:/platform_config.yml \
 -p 8080:8080 \
 -it volttron_local
 ``` 
 
-Step 3. Once the container is started and running, open http://0.0.0.0:8080 on a browser to view the Volttron web platform interface.
+Step 3. Once the container is started and running, set the master username and password on the Volttron Central Admin page at `http://localhost:8080/index.html`
 
+Step 4. To log in to Volttron Central, open a browser and login to the Volttron web interface: `http://localhost:8080/vc/index.html`
 
 # Raw Container Usage
 
 ``` bash
-# Retrieves and executes the volttron container.
-docker run -it volttron/volttron
+# Retrieves and creates a volttron container from the volttron/volttron:develop image on Volttron DockerHub
+$ docker run -it  -e LOCAL_USER_ID=$UID --name volttron1 --rm -d volttron/volttron:develop
 ```
 
 After entering the above command the shell will be within the volttron container as a user named volttron.
 
 ``` bash
-# starting the platform
-volttron -vv -l volttron.log&
+$ docker exec -itu volttron volttron1 bash
 
-# cd to volttron root
-cd $VOLTTRON_ROOT
+# check status of volttron platform
+$ vctl status
 
-# installing listener agent
-python scripts/core/make-listener
+# set environment variable, IGNORE_ENV_CHECK, to ignore virtual env in python
+$ export IGNORE_ENV_CHECK=1
 
-# see the log messages
-tail -f volttron.log
+# Install a ListenterAgent
+$ python3 scripts/install-agent.py -s examples/ListenerAgent --start
+
+# check status of volttron platform to verify ListenerAgent is installed
+$ vctl status
+
+# To Stop the container
+$ docker stop volttron1
 ```
 
 All the same functionality that one would have from a VOLTTRON command line is available through the container.

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ $ docker run \
 -it volttron_local
 ``` 
 
-Step 3. Once the container is started and running, set the master username and password on the Volttron Central Admin page at `http://localhost:8080/index.html`
+Step 3. Once the container is started and running, set the master username and password on the Volttron Central Admin page at `http://0.0.0.0:8080/index.html`
 
-Step 4. To log in to Volttron Central, open a browser and login to the Volttron web interface: `http://localhost:8080/vc/index.html`
+Step 4. To log in to Volttron Central, open a browser and login to the Volttron web interface: `http://0.0.0.0:8080/vc/index.html`
 
 # Raw Container Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,20 @@ services:
     hostname: vc
     image: volttron/volttron:develop
     ports:
+      # host_port:container_port
+
+      # http port for volttron central
       - 8080:8080
-      #- 23916:22916
+      # https port for volttron central
       #- 8443:8443
-      #- 6671:5671    # ampqs port
-      #- 25671:15671  # management port
+
+      #- 23916:22916
+
+      # rmq ampqs port
+      #- 5671:5671
+
+      # rmq mgmt ssl port
+      #- 15671:15671
     volumes:
       - ./platform_config.yml:/platform_config.yml
       - ./configs:/home/volttron/configs

--- a/platform_config.yml
+++ b/platform_config.yml
@@ -8,7 +8,7 @@ config:
   # in the docker compose file hostname field for the service.
   bind-web-address: http://0.0.0.0:8080
   volttron-central-address: http://0.0.0.0:8080
-  instance-name: foobar
+  instance-name: volttron1
   message-bus: zmq
   # volttron-central-address: a different address
   # volttron-central-serverkey: a different key
@@ -23,7 +23,7 @@ agents:
   # directory and will be used to install the agent.
   listener:
     source: $VOLTTRON_ROOT/examples/ListenerAgent
-    config: $CONFIG/listener.config # This is an empty element $CONFIG/listener.config
+    config: $CONFIG/listener.config
 
   volttron.central:
     source: $VOLTTRON_ROOT/services/core/VolttronCentral


### PR DESCRIPTION
What's the change?
* Update comments and values in docker-compose.yml, platform_config.yml
* Correct docker command examples in README

Why is it needed?
* To ensure that containers are properly built using 'docker run' commands stated in README

How tested?
* I went through each updated docker command in README and verified that container was created.