### PR TITLE
Fix setup-platform.py to not fail on agent installation

### DIFF
--- a/core/setup-platform.py
+++ b/core/setup-platform.py
@@ -217,7 +217,13 @@ if need_to_install:
         # This allows install agent to ignore the fact that we aren't running
         # form a virtual environment.
         envcpy['IGNORE_ENV_CHECK'] = "1"
-        subprocess.check_call(install_cmd, env=envcpy)
+        try:
+            subprocess.check_call(install_cmd, env=envcpy)
+        except subprocess.CalledProcessError as e:
+            # sometimes, the install command returns an Error saying that volttron couldn't install the agent, when in fact the agent was successfully installed
+            # this is most likely a bug in Volttron. For now, we are ignoring that error so that the setup of the Volttron platform does not fail and to allow Docker to start the container
+            sys.stderr.write(f"IGNORING ERROR: {e}")
+            continue
 
         if "config_store" in spec:
             sys.stdout.write("Processing config_store entries")


### PR DESCRIPTION
When setup-platform.py installs an agent, sometimes the platform returns an error message stating that the agent did not respond within the timeout period, causing the script to stop and the docker container to stop running even though the agent is installed. This appears to be a volttron bug and the error message seems to be a false positive. Adding a try/except block and allowing the script to continue will allow docker to complete the platform setup and run the docker container. 