### PR TITLE
Updated os/version and set for 9.0 release.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG image_repo=debian
-ARG image_tag=bullseye
+ARG image_repo=ubuntu
+ARG image_tag=20.04
 #
 FROM ${image_repo}:${image_tag} as volttron_base
 #
@@ -44,6 +44,9 @@ RUN set -eux; apt-get update; apt-get install -y --no-install-recommends \
     libffi-dev \
     sqlite3
 #
+# Set timezone
+RUN echo UTC > /etc/timezone
+
 # Set default 'python' to 'python3'
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   volttron1:
     container_name: volttron1
     hostname: volttron1
-    image: volttroncommunity/volttron:v8.2-zmq
+    image: volttroncommunity/volttron:v9.0-zmq
     ports:
       # host_port:container_port
       # http port for volttron central


### PR DESCRIPTION
- Pinned default to volttron 9.0 release.
- Renamed build to clarify it is zmq only.
- Changed from Debian (Bullseye) to Ubuntu (Focal Fossa).
- Added RUN statement to set /etc/timezone.